### PR TITLE
Fix the sample settings code for the template context processor.

### DIFF
--- a/docs/source/templating.rst
+++ b/docs/source/templating.rst
@@ -16,7 +16,7 @@ First you need to add a context processor to your settings, e.g.::
 
 
     TEMPLATE_CONTEXT_PROCESSORS = global_settings.TEMPLATE_CONTEXT_PROCESSORS + (
-        'plans.context_processors.expiration'
+        'plans.context_processors.account_status',
         )
 
 The context processor is defined as follows:


### PR DESCRIPTION
The fix is actually double:
- The function name was wrong (`account_status`, not `expiration`)
- The code was intended as a tuple, but a single-element tuple needs a
  trailing comma, or it'll just be a string.
