### PR TITLE
Allow projects to disable the sending of emails

### DIFF
--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -220,6 +220,15 @@ Example::
 
 Further reading: :doc:`quota_validators`
 
+``SEND_PLANS_EMAILS``
+------------------------------
+
+**Optional**
+
+Default: ``True``
+
+Boolean value for enabling (default) or disabling the sending of plan related emails.
+
 ``TAX``
 -------
 

--- a/plans/contrib.py
+++ b/plans/contrib.py
@@ -12,6 +12,10 @@ email_logger = logging.getLogger('emails')
 def send_template_email(recipients, title_template, body_template, context, language):
     """Sends e-mail using templating system"""
 
+    send_emails = getattr(settings, 'SEND_PLANS_EMAILS', True)
+    if not send_emails:
+        return
+
     site_name = getattr(settings, 'SITE_NAME', 'Please define settings.SITE_NAME')
     domain = getattr(settings, 'SITE_URL', None)
 

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -102,6 +102,17 @@ class PlansTestCase(TestCase):
         self.assertEqual(u.userplan.active, True)
         self.assertEqual(len(mail.outbox), 1)
 
+    def test_disable_emails(self):
+        with self.settings(SEND_PLANS_EMAILS=False):
+            # Re-run the remind_expire test, but look for 0 emails sent
+            u = User.objects.get(username='test1')
+            u.userplan.expire = date.today() + timedelta(days=14)
+            u.userplan.active = True
+            u.userplan.save()
+            u.userplan.remind_expire_soon()
+            self.assertEqual(u.userplan.active, True)
+            self.assertEqual(len(mail.outbox), 0)
+
 
 class TestInvoice(TestCase):
     fixtures = ['initial_plan', 'test_django-plans_auth', 'test_django-plans_plans']


### PR DESCRIPTION
Adds a global setting (`SEND_PLANS_EMAILS`, default: `True`) that allows projects to disable all email sending from the package. Also includes some documentation & a test for it.
