### PR TITLE
Support free plans.

### DIFF
--- a/plans/fixtures/test_django-plans_plans.json
+++ b/plans/fixtures/test_django-plans_plans.json
@@ -71,6 +71,18 @@
         }
     },
     {
+        "pk": 9,
+        "model": "plans.plan",
+        "fields": {
+            "available": true,
+            "visible": true,
+            "created": "2014-03-30T10:41:52.428Z",
+            "description": "Free Test",
+            "name": "Free",
+            "order": 6
+        }
+    },
+    {
         "pk": 6,
         "model": "plans.billinginfo",
         "fields": {

--- a/plans/locale/en/LC_MESSAGES/django.po
+++ b/plans/locale/en/LC_MESSAGES/django.po
@@ -370,12 +370,17 @@ msgstr ""
 msgid "Hi"
 msgstr ""
 
-#: templates/mail/change_plan_body.txt:4
+#: templates/mail/change_plan_body.txt:5
 #, python-format
 msgid "Your current plan is %(plan_name)s and it will expire on %(expire)s. "
 msgstr ""
 
-#: templates/mail/change_plan_body.txt:6
+#: templates/mail/change_plan_body.txt:7
+#, python-format
+msgid "Your current plan is %(plan_name)s. "
+msgstr ""
+
+#: templates/mail/change_plan_body.txt:10
 #: templates/mail/expired_account_body.txt:11
 #: templates/mail/extend_account_body.txt:8
 #: templates/mail/invoice_created_body.txt:11
@@ -721,7 +726,19 @@ msgstr ""
 msgid "Buy"
 msgstr ""
 
-#: templates/plans/plan_table.html:93
+#: templates/plans/plan_table.html:90
+msgid "Free"
+msgstr ""
+
+#: templates/plans/plan_table.html:91
+msgid "no expiry"
+msgstr ""
+
+#: templates/plans/plan_table.html:96
+msgid "Select"
+msgstr ""
+
+#: templates/plans/plan_table.html:109
 #, python-format
 msgid ""
 "\n"

--- a/plans/plan_change.py
+++ b/plans/plan_change.py
@@ -7,6 +7,9 @@ class PlanChangePolicy(object):
         """
         Finds most fitted plan pricing for a given period, and calculate day cost
         """
+        if plan.is_free():
+            # If plan is free then cost is always 0
+            return 0
 
         plan_pricings = plan.planpricing_set.order_by('-pricing__period').select_related('pricing')
         selected_pricing = None

--- a/plans/templates/mail/change_plan_body.txt
+++ b/plans/templates/mail/change_plan_body.txt
@@ -1,7 +1,11 @@
 {% load i18n %}{% autoescape off %}
 {% trans "Hi" %} {% firstof user.get_full_name user.username %},
 
-{% blocktrans with plan_name=plan.name expire=userplan.expire %}Your current plan is {{ plan_name }} and it will expire on {{ expire }}. {% endblocktrans %}
+{% if userplan.expire != None %}
+    {% blocktrans with plan_name=plan.name expire=userplan.expire %}Your current plan is {{ plan_name }} and it will expire on {{ expire }}. {% endblocktrans %}
+{% else %}
+    {% blocktrans with plan_name=plan.name %}Your current plan is {{ plan_name }}. {% endblocktrans %}
+{% endif %}
 
 {% trans "Thank you" %}
 --

--- a/plans/templates/plans/plan_table.html
+++ b/plans/templates/plans/plan_table.html
@@ -58,7 +58,7 @@
         <th></th>
         {% for plan in plan_list %}
         <th class="planpricing_footer {% ifequal forloop.counter0 current_userplan_index %}current{% endifequal %}">
-            {% if plan != userplan.plan and not userplan.is_expired %}
+            {% if plan != userplan.plan and not userplan.is_expired and not userplan.plan.is_free %}
                 <a href="{% url 'create_order_plan_change' pk=plan.id %}" class="change_plan">{% trans "Change" %}</a>{% endif %}
         </th>
         {% endfor %}
@@ -70,22 +70,38 @@
         <th></th>
         {% for plan in plan_list %}
             <th class="planpricing_footer {% ifequal forloop.counter0 current_userplan_index %}current{% endifequal %}">
-
-
                 {% if plan.available %}
-                <ul>
-                    {% for plan_pricing in plan.planpricing_set.all %}
+                    <ul>
+                    {% if not plan.is_free %}
+                        {% for plan_pricing in plan.planpricing_set.all %}
+                            <li>
+                            {% if plan_pricing.pricing.url %}<a href="{{ plan_pricing.pricing.url }}" class="info_link pricing">{% endif %}
+                            <span class="plan_pricing_name">{{ plan_pricing.pricing.name }}</span>
+                            <span class="plan_pricing_period">({{ plan_pricing.pricing.period }} {% trans "days" %})</span>
+                            {% if plan_pricing.pricing.url %}</a>{% endif %}
+                            <span class="plan_pricing_price">{{ plan_pricing.price }}&nbsp;{{ CURRENCY }}</span>
+                            {% if plan_pricing.plan == userplan.plan or userplan.is_expired or userplan.plan.is_free %}
+                            <a href="{% url 'create_order_plan' pk=plan_pricing.pk %}" class="buy">{% trans "Buy" %}</a>
+                            {% endif %}
+                        {% endfor %}
+                    {% else %}
+                        {# Allow selecting plans with no pricings #}
                         <li>
-                        {% if plan_pricing.pricing.url %}<a href="{{ plan_pricing.pricing.url }}" class="info_link pricing">{% endif %}
-                        <span class="plan_pricing_name">{{ plan_pricing.pricing.name }}</span>
-                        <span class="plan_pricing_period">({{ plan_pricing.pricing.period }} {% trans "days" %})</span>
-                        {% if plan_pricing.pricing.url %}</a>{% endif %}
-                        <span class="plan_pricing_price">{{ plan_pricing.price }}&nbsp;{{ CURRENCY }}</span>
-                        {% if plan_pricing.plan == userplan.plan or userplan.is_expired %}
-                        <a href="{% url 'create_order_plan' pk=plan_pricing.pk %}" class="buy">{% trans "Buy" %}</a>
-                        {% endif %}
-                    {% endfor %}
-                </ul>
+                            <span class="plan_pricing_name">{% trans "Free" %}</span>
+                            <span class="plan_pricing_period">({% trans "no expiry" %})</span>
+                            <span class="plan_pricing_price">0&nbsp;{{ CURRENCY }}</span>
+                            {% if plan != userplan.plan or userplan.is_expired %}
+                                <a href="{% url 'create_order_plan_change' pk=plan.id %}" class="change_plan">
+                                    {% if userplan.is_expired %}
+                                        {% trans "Select" %}
+                                    {% else %}
+                                        {% trans "Change" %}
+                                    {% endif %}
+                                </a>
+                            {% endif %}
+                        </li>
+                    {% endif %}
+                    </ul>
 
                    {% else %}
                      <span class="plan_not_available">

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -113,6 +113,26 @@ class PlansTestCase(TestCase):
             self.assertEqual(u.userplan.active, True)
             self.assertEqual(len(mail.outbox), 0)
 
+    def test_switch_to_free_no_expiry(self):
+        """
+        Tests switching to a free Plan and checks that their expiry is cleared
+        Tests if expire date is set correctly
+        Tests if mail has been send
+        Tests if account has been activated
+        """
+        u = User.objects.get(username='test1')
+        self.assertIsNotNone(u.userplan.expire)
+
+        plan = Plan.objects.get(name="Free")
+        self.assertTrue(plan.is_free())
+        self.assertNotEqual(u.userplan.plan, plan)
+
+        # Switch to Free Plan
+        u.userplan.extend_account(plan, None)
+        self.assertEquals(u.userplan.plan, plan)
+        self.assertIsNone(u.userplan.expire)
+        self.assertEqual(u.userplan.active, True)
+
 
 class TestInvoice(TestCase):
     fixtures = ['initial_plan', 'test_django-plans_auth', 'test_django-plans_plans']


### PR DESCRIPTION
Fixes #24

Plans without pricings will be `plan.is_free(): true`. Switching to these
plans causes the userplan have it's expiry field set to `None`

Since there's no `userplan.expiry`, the standard plan change process doesn't
make sense, so the plan table is adjusted to present the standard plan
order links rather than plan change links.

Note: I have not implemented the presentation layer/tagging suggestion 
from #24, but I think the handling of the free plan in the plan table may be 
sufficient for now (for our purposes it is).
