### PR TITLE
EUTaxationPolicy.get_tax_rate() condition fix

### DIFF
--- a/plans/taxation/eu.py
+++ b/plans/taxation/eu.py
@@ -35,6 +35,7 @@ class EUTaxationPolicy(TaxationPolicy):
         'FR', # France
         'DE', # Germany
         'GR', # Greece
+        'HR', # Croatia
         'HU', # Hungary
         'IE', # Ireland
         'IT', # Italy


### PR DESCRIPTION
There is an incorrect condition in get_tax_rate() method of EUTaxationPolicy class.
