### PR TITLE
allow dynamically create PLANS_VALIDATORS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 django-plans changelog
 ======================
 
+0.9.0
+-----
+* Added possibility to define PLANS_VALIDATORS as lazy imported string
+
 0.8.13
 ------
 * Supporting Django 2.0.6.

--- a/docs/source/settings.rst
+++ b/docs/source/settings.rst
@@ -217,6 +217,10 @@ Example::
         'MAX_STORAGE' :  'myproject.validators.max_storage_validator',
     }
 
+The dict itself could be also lazy imported string::
+
+    PLANS_VALIDATORS = 'myproject.validators.validator_dict'
+
 
 Further reading: :doc:`quota_validators`
 

--- a/plans/importer.py
+++ b/plans/importer.py
@@ -1,4 +1,8 @@
 def import_name(name):
-    components = name.split('.')
-    mod = __import__('.'.join(components[0:-1]), globals(), locals(), [components[-1]] )
-    return getattr(mod, components[-1])
+    """ import module given by str or pass the module if it is not str """
+    if isinstance(name, str):
+        components = name.split('.')
+        mod = __import__('.'.join(components[0:-1]), globals(), locals(), [components[-1]] )
+        return getattr(mod, components[-1])
+    else:
+        return name

--- a/plans/validators.py
+++ b/plans/validators.py
@@ -121,6 +121,7 @@ def plan_validation(user, plan=None, on_activation=False):
         plan = user.userplan.plan
     quota_dict = plan.get_quota_dict()
     validators = getattr(settings, 'PLANS_VALIDATORS', {})
+    validators = import_name(validators)
     errors = {
         'required_to_activate': [],
         'other': [],


### PR DESCRIPTION
This enables PLANS_VALIDATORS be dynamically generated through lazy imported dict defined throught string.