### PR TITLE
Add autocomplete_fields in Admin and other updates

### DIFF
--- a/plans/admin.py
+++ b/plans/admin.py
@@ -25,10 +25,12 @@ class UserLinkMixin(object):
 
 class PlanQuotaInline(admin.TabularInline):
     model = PlanQuota
+    autocomplete_fields = ['quota']
 
 
 class PlanPricingInline(admin.TabularInline):
     model = PlanPricing
+    autocomplete_fields = ['pricing']
 
 
 class QuotaAdmin(OrderedModelAdmin):
@@ -38,6 +40,7 @@ class QuotaAdmin(OrderedModelAdmin):
     ]
 
     list_display_links = list_display
+    search_fields = ['codename', 'name']
 
 
 def copy_plan(modeladmin, request, queryset):
@@ -78,6 +81,8 @@ class PlanAdmin(OrderedModelAdmin):
     list_select_related = True
     raw_id_fields = ('customized',)
     actions = [copy_plan, ]
+    
+    autocomplete_fields = ['customized']
 
     def queryset(self, request):
         return super(PlanAdmin, self).queryset(request).select_related(
@@ -92,6 +97,7 @@ class BillingInfoAdmin(UserLinkMixin, admin.ModelAdmin):
     list_select_related = True
     readonly_fields = ('user_link',)
     exclude = ('user',)
+    autocomplete_fields = ['user']
 
 
 def make_order_completed(modeladmin, request, queryset):
@@ -117,6 +123,7 @@ class InvoiceInline(admin.TabularInline):
     raw_id_fields = (
         'user',
     )
+    autocomplete_fields = ['user']
 
 
 class OrderAdmin(admin.ModelAdmin):
@@ -133,7 +140,11 @@ class OrderAdmin(admin.ModelAdmin):
     list_display_links = list_display
     actions = [make_order_completed, make_order_invoice]
     inlines = (InvoiceInline, )
-
+    autocomplete_fields = [
+        'user',
+        'plan',
+        'pricing'
+    ]
     def queryset(self, request):
         return super(OrderAdmin, self).queryset(request).select_related('plan', 'pricing', 'user')
 
@@ -151,6 +162,7 @@ class InvoiceAdmin(admin.ModelAdmin):
     list_display_links = list_display
     list_select_related = True
     raw_id_fields = ('user', 'order')
+    autocomplete_fields = ['user', 'order']
 
 
 class UserPlanAdmin(UserLinkMixin, admin.ModelAdmin):
@@ -162,6 +174,10 @@ class UserPlanAdmin(UserLinkMixin, admin.ModelAdmin):
     readonly_fields = ['user_link', ]
     fields = ('user', 'user_link', 'plan', 'expire', 'active' )
     raw_id_fields = ['user', 'plan', ]
+    autocomplete_fields = [
+        'user',
+        'plan'
+    ]
 
 
 admin.site.register(Quota, QuotaAdmin)

--- a/plans/admin.py
+++ b/plans/admin.py
@@ -38,6 +38,10 @@ class QuotaAdmin(OrderedModelAdmin):
         'codename', 'name', 'description', 'unit',
         'is_boolean', 'move_up_down_links',
     ]
+    list_filter = [
+        'unit',
+        'is_boolean'
+    ]
 
     list_display_links = list_display
     search_fields = ['codename', 'name']
@@ -71,7 +75,7 @@ copy_plan.short_description = _('Make a plan copy')
 
 class PlanAdmin(OrderedModelAdmin):
     search_fields = ('name', 'customized__username', 'customized__email', )
-    list_filter = ('available', 'visible')
+    list_filter = ('available', 'visible', 'default', 'created')
     list_display = [
         'name', 'description', 'customized', 'default', 'available',
         'created', 'move_up_down_links'
@@ -127,7 +131,10 @@ class InvoiceInline(admin.TabularInline):
 
 
 class OrderAdmin(admin.ModelAdmin):
-    list_filter = ('status', 'created', 'completed', 'plan__name', 'pricing')
+    list_filter = (
+        'status', 'created', 'completed', 'plan__name', 'pricing', 'plan_extended_from',
+        'plan_extended_until', 'currency'
+    )
     raw_id_fields = ('user',)
     search_fields = (
         'id', 'user__username', 'user__email', 'invoice__full_number'
@@ -179,6 +186,7 @@ class UserPlanAdmin(UserLinkMixin, admin.ModelAdmin):
         'plan'
     ]
 
+
 class PricingAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'period', 'visible'
@@ -190,8 +198,8 @@ class PricingAdmin(admin.ModelAdmin):
     search_fields = [
         'name'
     ]
-    
-    
+
+
 admin.site.register(Quota, QuotaAdmin)
 admin.site.register(Plan, PlanAdmin)
 admin.site.register(UserPlan, UserPlanAdmin)

--- a/plans/admin.py
+++ b/plans/admin.py
@@ -179,11 +179,23 @@ class UserPlanAdmin(UserLinkMixin, admin.ModelAdmin):
         'plan'
     ]
 
-
+class PricingAdmin(admin.ModelAdmin):
+    list_display = [
+        'name', 'period', 'visible'
+    ]
+    list_filter = [
+        'visible',
+        'period',
+    ]
+    search_fields = [
+        'name'
+    ]
+    
+    
 admin.site.register(Quota, QuotaAdmin)
 admin.site.register(Plan, PlanAdmin)
 admin.site.register(UserPlan, UserPlanAdmin)
-admin.site.register(Pricing)
+admin.site.register(Pricing, PricingAdmin)
 admin.site.register(Order, OrderAdmin)
 admin.site.register(BillingInfo, BillingInfoAdmin)
 admin.site.register(Invoice, InvoiceAdmin)

--- a/plans/models.py
+++ b/plans/models.py
@@ -55,7 +55,7 @@ class Plan(OrderedModel):
     is using this plan already will be able to extend this plan again. If plan is not visible and not
     available, he will be forced then to change plan next time he extends an account.
     """
-    name = models.CharField(_('name'), max_length=100)
+    name = models.CharField(_('Plan Name'), max_length=100)
     description = models.TextField(_('description'), blank=True)
     default = models.NullBooleanField(
         help_text=_('Both "Unknown" and "No" means that the plan is not default'),

--- a/plans/models.py
+++ b/plans/models.py
@@ -351,7 +351,11 @@ class Pricing(models.Model):
         _('period'), default=30, null=True, blank=True, db_index=True)
     url = models.URLField(max_length=200, blank=True, help_text=_(
         'Optional link to page with more information (for clickable pricing table headers)'))
-
+    visible = models.BooleanField(
+        _('visible'), default=True, db_index=True,
+        help_text=_('Is visible in current offer')
+    )
+    
     class Meta:
         ordering = ('period',)
         verbose_name = _("Pricing")

--- a/plans/models.py
+++ b/plans/models.py
@@ -64,11 +64,11 @@ class Plan(OrderedModel):
         unique=True,
     )
     available = models.BooleanField(
-        _('available'), default=False, db_index=True,
+        _('Plan Available'), default=False, db_index=True,
         help_text=_('Is still available for purchase')
     )
     visible = models.BooleanField(
-        _('visible'), default=True, db_index=True,
+        _('Plan Visible'), default=True, db_index=True,
         help_text=_('Is visible in current offer')
     )
     created = models.DateTimeField(_('created'), db_index=True)


### PR DESCRIPTION
The update include

- Add `autocomplete_fields` to foreign key fields to enable select2 ajax searchable foreign key field. This will reduce queries and optimize admin page when related objects are large in the count.
- Add `PricingAdmin`. Required to add `search_fields` to add in `autocomplete_fields`.
- Add **list_filters**. Add a few possible fields to the list_filters list.
- Update verbose name. Updated verbose names of `name`, `available`, `visible` fields of **Plan** model to improve visibility in the filter list.
- Add `visible` field to the `Pricing` model. Sometimes admin wants to hide a few pricing but can not delete it as there might be existing users under this pricing.