### PR TITLE
increase overridability of order_list.html template

### DIFF
--- a/plans/templates/plans/order_list.html
+++ b/plans/templates/plans/order_list.html
@@ -3,11 +3,16 @@
 
 
 {% block body %}
+    {% block order_header %}
     <h1>{% trans "List of orders" %}</h1>
+    {% endblock %}
 
     {% if object_list %}
+    {% block pagination_first %}
     {% include "plans/pagination.html" %}
+    {% endblock %}
 
+    {% block order_table %}
     <table class="table">
         <thead>
             <tr>
@@ -36,8 +41,11 @@
             {% endfor %}
         </tbody>
     </table>
+    {% endblock %}
 
+    {% block pagination_second %}
     {% include "plans/pagination.html" %}
+    {% endblock %}
 
     {% else %}
         {% blocktrans %}You do not have any orders so far.{% endblocktrans %}

--- a/plans/templates/plans/pagination.html
+++ b/plans/templates/plans/pagination.html
@@ -2,7 +2,7 @@
 {% if is_paginated %}
     <ul class="pagination">
         {% if page_obj.has_previous %}
-            <li><a href="?page={{ page_obj.previous_page_number }}&query={{ query }}">&laquo;</a></li>
+            <li><a class="pagination__prev" href="?page={{ page_obj.previous_page_number }}&query={{ query }}">&laquo;</a></li>
         {% else %}
             <li class="disabled"><span>&laquo;</span></li>
         {% endif %}
@@ -14,7 +14,7 @@
         {% endfor %}
 
         {% if page_obj.has_next %}
-            <li><a href="?page={{ page_obj.next_page_number }}&query={{ query }}">&raquo;</a></li>
+            <li><a class="pagination__next" href="?page={{ page_obj.next_page_number }}&query={{ query }}">&raquo;</a></li>
         {% else %}
             <li class="disabled"><span>&raquo;</span></li>
         {% endif %}


### PR DESCRIPTION
 and add CSS classes, that allow easy setting with infinite scroll

BTW if you want to enable infinite scroll, the code is:

```python
jQuery(document).ready(function($) {
   var infScroll_invoices = new InfiniteScroll( '.order_list .table tbody', {
     path: '.pagination__next',
     append: '.order_list .table tbody tr',
     hideNav: '.pagination',
   });
   $('.infinite-container').bind("DOMNodeInserted", function(){
      new LazyLoad({
          elements_selector: ".lazy"
      });
   });
});
```