### PR TITLE
Fix #118

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: python
 python:
   - "3.6"
   - "3.7"
+before_script:
+  - psql -c 'create database travis_ci_test;' -U postgres
+services:
+  - postgresql
 env:
   - DJANGO_VERSION=2.0.*
   - DJANGO_VERSION=2.1.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ services:
 env:
   - DJANGO_VERSION=2.0.*
   - DJANGO_VERSION=2.1.*
+  - DJANGO_VERSION=2.2.*
   - DJANGO_VERSION=3.0.*
 # command to install dependencies
 install:

--- a/demo/example/settings.py
+++ b/demo/example/settings.py
@@ -120,10 +120,12 @@ INSTALLED_APPS = [
 
     'ordered_model',
     'bootstrap3',
+    'django_concurrent_tests',
 
     'plans',
     'example.foo',
-    'django_extensions'
+    'django_extensions',
+    'sequences.apps.SequencesConfig',
 ]
 
 LOGGING = {

--- a/demo/example/settings.py
+++ b/demo/example/settings.py
@@ -24,10 +24,10 @@ MANAGERS = ADMINS
 
 DATABASES = {
     'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
+        'ENGINE': 'django.db.backends.postgresql',
         # Add 'postgresql_psycopg2', 'postgresql', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': 'plans_example.sqlite',  # Or path to database file if using sqlite3.
-        'USER': '',  # Not used with sqlite3.
+        'NAME': 'travis_ci_test',  # Or path to database file if using sqlite3.
+        'USER': 'postgres',  # Not used with sqlite3.
         'PASSWORD': '',  # Not used with sqlite3.
         'HOST': '',  # Set to empty string for localhost. Not used with sqlite3.
         'PORT': '',  # Set to empty string for default. Not used with sqlite3.

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -9,6 +9,8 @@ tox
 suds-jurko
 maxminddb-geolite2
 model_bakery
+django-concurrent-test-helper
+freezegun
 
 
 # Not supported in py3

--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -11,6 +11,7 @@ maxminddb-geolite2
 model_bakery
 django-concurrent-test-helper
 freezegun
+psycopg2
 
 
 # Not supported in py3

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,6 +10,12 @@ You can install app using package manager directly from github:
 
     $ pip install django-plans
 
+Add following applications to `INSTALLED_APPS`::
+
+    INSTALLED_APPS += (
+        'plans',
+        'sequences.apps.SequencesConfig',
+    )
 
 For integration instruction please see section  :doc:`integration`.
 
@@ -18,6 +24,22 @@ If you want to determine billing info default country by IP address, install `ge
 .. code-block:: bash
 
     $ pip install maxminddb-geolite2
+
+
+Invoice sequences
+-----------------
+
+The `django-plans` application use `django-sequences` to generate sequence of invoice numbers without gaps and duplicities.
+Be aware, that if the database isolation level is set to `ISOLATION_LEVEL_REPEATABLE_READ` or `ISOLATION_LEVEL_SERIALIZABLE`,
+the concurrent creation of two invoices could throw `OperationalError: could not serialize access due to concurrent update`.
+If you use such non-default isolation levels, you can either ignore this (if you think, that creation of two invoices at the
+same time is highly inprobable in your app), repeat the operation or set different isolation level only for invoice creation transaction with::
+
+    from django.db import connection
+
+    with transaction.atomic():
+        cursor = connection.cursor()
+        cursor.execute('SET TRANSACTION ISOLATION LEVEL REPEATABLE READ')
 
 
 Running example project

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
         'django-next-url-mixin==0.1.0',
         'celery',
         'suds-jurko',
+        'django-sequences',
         'six',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,5 @@ deps =
     django-22: Django>=2.1,<3.0
     django-30: Django>=3.0,<3.1
     -r{toxinidir}/demo/requirements.txt
-commands=coverage run demo/manage.py test {posargs:plans}
+changedir=demo
+commands=coverage run manage.py test {posargs:plans}

--- a/tox.ini
+++ b/tox.ini
@@ -14,4 +14,4 @@ deps =
     django-22: Django>=2.1,<3.0
     django-30: Django>=3.0,<3.1
     -r{toxinidir}/demo/requirements.txt
-commands=coverage run demo/manage.py test plans
+commands=coverage run demo/manage.py test {posargs:plans}


### PR DESCRIPTION
- includes test for duplicate invoice numbers
- adds dependency on `django-sequences`
- includes related changes in documentation related to the added dependency and consulting different database isolation levels
- changes testing DB to PostgreSQL in order to test the duplicities