### PR TITLE
fix managers (get_query_set was renamed to get_queryset from Django 1.6)

### DIFF
--- a/plans/models.py
+++ b/plans/models.py
@@ -498,8 +498,8 @@ class Quota(OrderedModel):
 
 
 class PlanPricingManager(models.Manager):
-    def get_query_set(self):
-        return super(PlanPricingManager, self).get_query_set().select_related('plan', 'pricing')
+    def get_queryset(self):
+        return super(PlanPricingManager, self).get_queryset().select_related('plan', 'pricing')
 
 
 class PlanPricing(models.Model):
@@ -525,8 +525,8 @@ class PlanPricing(models.Model):
 
 
 class PlanQuotaManager(models.Manager):
-    def get_query_set(self):
-        return super(PlanQuotaManager, self).get_query_set().select_related('plan', 'quota')
+    def get_queryset(self):
+        return super(PlanQuotaManager, self).get_queryset().select_related('plan', 'quota')
 
 
 class PlanQuota(models.Model):
@@ -669,18 +669,18 @@ class Order(models.Model):
 
 
 class InvoiceManager(models.Manager):
-    def get_query_set(self):
-        return super(InvoiceManager, self).get_query_set().filter(type=Invoice.INVOICE_TYPES['INVOICE'])
+    def get_queryset(self):
+        return super(InvoiceManager, self).get_queryset().filter(type=Invoice.INVOICE_TYPES['INVOICE'])
 
 
 class InvoiceProformaManager(models.Manager):
-    def get_query_set(self):
-        return super(InvoiceProformaManager, self).get_query_set().filter(type=Invoice.INVOICE_TYPES['PROFORMA'])
+    def get_queryset(self):
+        return super(InvoiceProformaManager, self).get_queryset().filter(type=Invoice.INVOICE_TYPES['PROFORMA'])
 
 
 class InvoiceDuplicateManager(models.Manager):
-    def get_query_set(self):
-        return super(InvoiceDuplicateManager, self).get_query_set().filter(type=Invoice.INVOICE_TYPES['DUPLICATE'])
+    def get_queryset(self):
+        return super(InvoiceDuplicateManager, self).get_queryset().filter(type=Invoice.INVOICE_TYPES['DUPLICATE'])
 
 
 class Invoice(models.Model):


### PR DESCRIPTION
The `get_query_set()` function was renamed to `get_queryset()` from Django 1.6, but `django-plans` didn't reflect that yet.