### PR TITLE
Fix greece taxation

### DIFF
--- a/plans/models.py
+++ b/plans/models.py
@@ -34,6 +34,7 @@ from plans.contrib import send_template_email, get_user_language
 from plans.signals import (order_completed, account_activated,
                            account_expired, account_change_plan,
                            account_deactivated)
+from plans.utils import country_code_transform
 
 from sequences import get_next_value
 
@@ -154,7 +155,7 @@ class BillingInfo(models.Model):
         number = tax_number
         if tax_number.startswith(country):
             number = tax_number[len(country):]
-        return country + number
+        return country_code_transform(country) + number
 
     @staticmethod
     def clean_tax_number(tax_number, country):

--- a/plans/taxation/eu.py
+++ b/plans/taxation/eu.py
@@ -6,6 +6,7 @@ from suds.transport import TransportError
 import vatnumber
 import stdnum
 from plans.taxation import TaxationPolicy
+from plans.utils import country_code_transform
 
 logger = logging.getLogger('plans.taxation.eu.vies')
 
@@ -60,11 +61,12 @@ class EUTaxationPolicy(TaxationPolicy):
 
     @classmethod
     def is_in_EU(cls, country_code):
-        return country_code.upper() in cls.EU_COUNTRIES_VAT
+        return country_code_transform(country_code).upper() in cls.EU_COUNTRIES_VAT
 
     @classmethod
     def get_default_tax(cls):
         issuer_country_code = cls.get_issuer_country_code()
+        issuer_country_code = country_code_transform(issuer_country_code)
         try:
             return cls.EU_COUNTRIES_VAT[issuer_country_code]
         except KeyError:
@@ -72,6 +74,7 @@ class EUTaxationPolicy(TaxationPolicy):
 
     @classmethod
     def get_tax_rate(cls, tax_id, country_code):
+        country_code = country_code_transform(country_code)
         issuer_country_code = cls.get_issuer_country_code()
         if not cls.is_in_EU(issuer_country_code):
             raise ImproperlyConfigured("EUTaxationPolicy requires that issuer country is in EU")

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -758,6 +758,20 @@ class EUTaxationPolicyTestCase(TestCase):
         with self.settings(PLANS_TAX=Decimal('23.0'), PLANS_TAX_COUNTRY='PL'):
             self.assertEqual(self.policy.get_tax_rate('123456', 'PL'), Decimal('23.0'))
 
+    def test_company_EU_GR_vies_tax(self):
+        """
+        Test, that greece has VAT OK. Greece has code GR in django-countries, but EL in VIES
+        Tax ID is not valid VAT ID, so tax is counted
+        """
+        self.assertEqual(self.policy.get_tax_rate('123456', 'GR'), 24)
+
+    def test_company_EU_GR_vies_zero(self):
+        """
+        Test, that greece has VAT OK. Greece has code GR in django-countries, but EL in VIES
+        Tax ID is valid VAT ID, so no tax is counted
+        """
+        self.assertEqual(self.policy.get_tax_rate('EL090145420', 'GR'), None)
+
     @mock.patch("vatnumber.check_vies", lambda x: True)
     def test_company_EU_notsame_vies_ok(self):
         with self.settings(PLANS_TAX=Decimal('23.0'), PLANS_TAX_COUNTRY='PL'):
@@ -779,6 +793,10 @@ class BillingInfoTestCase(TestCase):
 
     def test_clean_tax_number_valid_with_country(self):
         self.assertEqual(BillingInfo.clean_tax_number('CZ48136450', 'CZ'), 'CZ48136450')
+
+    def test_clean_tax_number_vat_id_is_not_correct(self):
+        with self.assertRaisesRegexp(ValidationError, 'VAT ID is not correct'):
+            BillingInfo.clean_tax_number('GR48136450', 'GR')
 
     def test_clean_tax_number_country_code_does_not_equal_as_country(self):
         with self.assertRaisesRegexp(ValidationError, 'VAT ID country code doesn\'t corespond with country'):
@@ -803,6 +821,12 @@ class CreateOrderViewTestCase(TestCase):
 
         o = c.recalculate(10, BillingInfo(tax_number='1234565', country='CZ'))
         self.assertEqual(o.tax, 21)
+
+        o = c.recalculate(10, BillingInfo(tax_number='1234567', country='GR'))
+        self.assertEqual(o.tax, 24)
+
+        o = c.recalculate(10, BillingInfo(tax_number='090145420', country='GR'))
+        self.assertEqual(o.tax, None)
 
 
 class ValidatorsTestCase(TestCase):

--- a/plans/utils.py
+++ b/plans/utils.py
@@ -1,0 +1,7 @@
+
+def country_code_transform(country_code):
+    """ Transform country code to the code used by VIES """
+    transform_dict = {
+        "GR": "EL",
+    }
+    return transform_dict.get(country_code, country_code)


### PR DESCRIPTION
Greece does have code GR in `django-countries`, but the EU code used by VIES is EL.
This fixes that problem and adds tests.