### PR TITLE
fix calculating recurring VAT - it is recalculated every time (in case Billing info changes)

### DIFF
--- a/plans/forms.py
+++ b/plans/forms.py
@@ -1,36 +1,10 @@
 from django import forms
-from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.forms.widgets import HiddenInput
 from django.utils.translation import ugettext
 
-from .models import PlanPricing, BillingInfo
-from plans.models import Order
-
-
-def get_client_ip(request):
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        ip = x_forwarded_for.split(',')[0]
-    else:
-        ip = request.META.get('REMOTE_ADDR')
-    return ip
-
-
-def get_country_code(request):
-    if getattr(settings, 'PLANS_GET_COUNTRY_FROM_IP', False):
-        try:
-            from geolite2 import geolite2
-            reader = geolite2.reader()
-            ip_address = get_client_ip(request)
-            ip_info = reader.get(ip_address)
-        except ModuleNotFoundError:
-            ip_info = None
-
-        if ip_info and 'country' in ip_info:
-            country_code = ip_info['country']['iso_code']
-            return country_code
-    return getattr(settings, 'PLANS_DEFAULT_COUNTRY', None)
+from .models import BillingInfo, Order, PlanPricing
+from .utils import get_country_code
 
 
 class OrderForm(forms.Form):

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -969,6 +969,15 @@ class RecurringPlansTestCase(TestCase):
         user_plan.recurring.token_verified = True
         self.assertEquals(user_plan.has_automatic_renewal(), True)
 
+    def test_create_new_order(self):
+        rup = baker.make(
+            'RecurringUserPlan',
+            user_plan__user__billinginfo__country='CZ',
+            amount=10,
+        )
+        order = rup.create_renew_order()
+        self.assertEqual(order.tax, 21)
+
 
 class TasksTestCase(TestCase):
     def test_expire_account_task(self):

--- a/plans/utils.py
+++ b/plans/utils.py
@@ -1,0 +1,34 @@
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from geolite2 import geolite2
+
+
+def get_client_ip(request):
+    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
+    if x_forwarded_for:
+        ip = x_forwarded_for.split(',')[0]
+    else:
+        ip = request.META.get('REMOTE_ADDR')
+    return ip
+
+
+def get_country_code(request):
+    if getattr(settings, 'PLANS_GET_COUNTRY_FROM_IP', False):
+        try:
+            reader = geolite2.reader()
+            ip_address = get_client_ip(request)
+            ip_info = reader.get(ip_address)
+        except ModuleNotFoundError:
+            ip_info = None
+
+        if ip_info and 'country' in ip_info:
+            country_code = ip_info['country']['iso_code']
+            return country_code
+    return getattr(settings, 'PLANS_DEFAULT_COUNTRY', None)
+
+
+def get_currency():
+    CURRENCY = getattr(settings, 'PLANS_CURRENCY', '')
+    if len(CURRENCY) != 3:
+        raise ImproperlyConfigured('PLANS_CURRENCY should be configured as 3-letter currency code.')
+    return CURRENCY


### PR DESCRIPTION
If user enters (changes) his/hers VAT ID after the first recurring payment, the VAT in the next recurring payments should update accordingly.
This MR fixes it and adds test for that.