### PR TITLE
fix Greece tax validation

### DIFF
--- a/plans/models.py
+++ b/plans/models.py
@@ -163,6 +163,9 @@ class BillingInfo(models.Model):
         tax_number = re.sub(r'[^A-Z0-9]', '', tax_number.upper())
 
         country_str = tax_number[:len(country)]
+        if country_str == country_code_transform(country):
+            country = country_code_transform(country)
+
         if country_str.isalpha() and country_str != country:
             raise ValidationError(_('VAT ID country code doesn\'t corespond with country'))
 

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -802,6 +802,12 @@ class BillingInfoTestCase(TestCase):
     def test_clean_tax_number_valid_with_country(self):
         self.assertEqual(BillingInfo.clean_tax_number('CZ48136450', 'CZ'), 'CZ48136450')
 
+    def test_clean_tax_number_valid_with_country_GR(self):
+        self.assertEqual(BillingInfo.clean_tax_number('GR104594676', 'GR'), 'EL104594676')
+
+    def test_clean_tax_number_valid_with_country_EL(self):
+        self.assertEqual(BillingInfo.clean_tax_number('EL104594676', 'GR'), 'EL104594676')
+
     def test_clean_tax_number_vat_id_is_not_correct(self):
         with self.assertRaisesRegex(ValidationError, 'VAT ID is not correct'):
             BillingInfo.clean_tax_number('GR48136450', 'GR')


### PR DESCRIPTION
There was one more problem with validation of Greece VAT IDs. This fixes that and adds tests for that.