### PR TITLE
Unify BillingInfo view to only one CreateOrUpdate view

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
 django-plans changelog
 ======================
 
+x.x.x
+-----
+* Transform BillingInfo create and update view into one BillingInfoCreateOrUpdateView. This will require implementors to change these views if they were overriden. Also if one of the `billing_info_create.html` or `billing_info_update.html` templates has been overriden, he has to transform the code into the new `billing_info_create_or_update.html` template.
+
 1.0.0
 -----
 * Celery dependency was removed. Now the implementor has to connect the `plans.tasks.autorenew_account` `plans.tasks.expire_account` tasks by himself or use management command.

--- a/demo/example/sample_plans/templates/plans/billing_info_create_or_update.html
+++ b/demo/example/sample_plans/templates/plans/billing_info_create_or_update.html
@@ -4,12 +4,14 @@
 {% block body %}
     <div class="row">
         <div class="col-sm-6">
-            <form action="{% url 'billing_info_update' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}" method="post" class="form">
+            <form action="{% block "action_url" %}{% url 'billing_info' %}{% endblock %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}" method="post" class="form">
                 {% block "form-content" %}
                 <legend>{% trans "Provide billing data" %}</legend>
                 {% csrf_token %}
                 {{ form.as_p }}
+                {% if object %}
                 <a class="btn btn-danger" href="{% url 'billing_info_delete' %}">Delete</a>
+                {% endif %}
                 <button type="submit" class="btn btn-primary">
                     Save
                 </button>

--- a/demo/example/sample_plans/templates/plans/plan_table.html
+++ b/demo/example/sample_plans/templates/plans/plan_table.html
@@ -32,13 +32,13 @@
             {% for plan_quota in quota_row.1 %}
 
                 <td class="{% if forloop.counter0 == current_userplan_index %}current{% endif %}">
-                    {% ifnotequal plan_quota None %}
+                    {% if plan_quota != None %}
                         {% if quota_row.0.is_boolean %}
                             {% if plan_quota.value %} + {% else %} - {% endif %}
                         {% else %}
                             {% if plan_quota.value == None %}{% trans 'no limit' %}{% else %}{{ plan_quota.value }} {{ quota_row.0.unit }}{% endif %}
                         {% endif %}
-                    {% endifnotequal %}
+                    {% endif %}
                 </td>
             {% endfor %}
 

--- a/docs/source/invoicing.rst
+++ b/docs/source/invoicing.rst
@@ -41,10 +41,7 @@ There are four class-based views to manage deleting and adding billing data:
 .. autoclass:: plans.views.BillingInfoRedirectView
 
 
-.. autoclass:: plans.views.BillingInfoCreateView
-
-
-.. autoclass:: plans.views.BillingInfoUpdateView
+.. autoclass:: plans.views.BillingInfoCreateOrUpdateView
 
 
 .. autoclass:: plans.views.BillingInfoDeleteView
@@ -57,8 +54,7 @@ Described views are pointed by following urls name patterns:
 
 Described views require creating following templates:
    * ``billing_info``,
-   * ``plans/billing_info_create.html``,
-   * ``plans/billing_info_update.html``,
+   * ``plans/billing_info_create_or_update.html``,
    * ``plans/billing_info_delete.html``.
 
 

--- a/plans/templates/plans/billing_info_create_or_update.html
+++ b/plans/templates/plans/billing_info_create_or_update.html
@@ -4,12 +4,14 @@
 {% block body %}
     <div class="row">
         <div class="col-sm-6">
-            <form action="{% url 'billing_info_create' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}" method="post" class="form">
+            <form action="{% block "action_url" %}{% url 'billing_info' %}{% endblock %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}" method="post" class="form">
                 {% block "form-content" %}
                 <legend>{% trans "Provide billing data" %}</legend>
-
                 {% csrf_token %}
                 {{ form.as_p }}
+                {% if object %}
+                <a class="btn btn-danger" href="{% url 'billing_info_delete' %}">Delete</a>
+                {% endif %}
                 <button type="submit" class="btn btn-primary">
                     Save
                 </button>

--- a/plans/urls.py
+++ b/plans/urls.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 from django.urls import path
 
-from plans.views import (AccountActivationView, BillingInfoCreateView,
-                         BillingInfoDeleteView, BillingInfoRedirectView,
-                         BillingInfoUpdateView, ChangePlanView,
+from plans.views import (AccountActivationView, BillingInfoCreateOrUpdateView,
+                         BillingInfoDeleteView, ChangePlanView,
                          CreateOrderPlanChangeView, CreateOrderView,
                          CurrentPlanView, FakePaymentsView, InvoiceDetailView,
                          OrderListView, OrderPaymentReturnView, OrderView,
-                         PricingView, UpgradePlanView)
+                         PricingView, RedirectToBilling, UpgradePlanView)
 
 urlpatterns = [
     path('pricing/', PricingView.as_view(), name='pricing'),
@@ -23,9 +22,11 @@ urlpatterns = [
          name='order_payment_success'),
     path('order/<int:pk>/payment/failure/', OrderPaymentReturnView.as_view(status='failure'),
          name='order_payment_failure'),
-    path('billing/', BillingInfoRedirectView.as_view(), name='billing_info'),
-    path('billing/create/', BillingInfoCreateView.as_view(), name='billing_info_create'),
-    path('billing/update/', BillingInfoUpdateView.as_view(), name='billing_info_update'),
+    # Redirect for backward compatibility:
+    path('billing/create/', RedirectToBilling.as_view(), name='billing_info_create'),
+    # Redirect for backward compatibility:
+    path('billing/update/', RedirectToBilling.as_view(), name='billing_info_update'),
+    path('billing/', BillingInfoCreateOrUpdateView.as_view(), name='billing_info'),
     path('billing/delete/', BillingInfoDeleteView.as_view(), name='billing_info_delete'),
     path('invoice/<int:pk>/preview/html/', InvoiceDetailView.as_view(), name='invoice_preview_html'),
 ]


### PR DESCRIPTION
The current situation with CreateBillingInfo and UpdateBillingInvo views has several disadvantages:
* It gives user unnecessary 404 or other errors if he lands on wrong variant (for example has left the create page in browser and in different tab already created the Billing info)
* Code duplication (at least between templates)
* Unnecessary code

This unifies the two views into one that works both ways.

This makes the code a bit backwards incompatible, because if somebody did override the `billing_info_create.html` or `billing_info_update.html` templates, he has to transform the code into the new `billing_info_create_or_update.html` template. Same applies to the views itself.
I made transitional redirect view from the `billing_info_create` and `billing_info_update` with deprecation warnings.

I also included tests for posting billing info that was not tested before.