### PR TITLE
Fixed geolite2 import

### DIFF
--- a/plans/utils.py
+++ b/plans/utils.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
-from geolite2 import geolite2
 
 
 def get_client_ip(request):
@@ -15,6 +14,8 @@ def get_client_ip(request):
 def get_country_code(request):
     if getattr(settings, 'PLANS_GET_COUNTRY_FROM_IP', False):
         try:
+            from geolite2 import geolite2
+
             reader = geolite2.reader()
             ip_address = get_client_ip(request)
             ip_info = reader.get(ip_address)


### PR DESCRIPTION
Determining country from IP address is an optional feature.
geolite2 was being imported directly ignoring the usecase
that it might not be installed.

geolite2 import has been moved to the get_contry_code method
inside try-except block.

Closes https://github.com/django-getpaid/django-plans/issues/157