### PR TITLE
Fix base/models/get_initial_number not fetching the highest number

### DIFF
--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -1066,10 +1066,7 @@ class InvoiceDuplicateManager(models.Manager):
 
 
 def get_initial_number(older_invoices):
-    return (
-        getattr(older_invoices.order_by("number").values("number").last(), "number", 0)
-        + 1
-    )
+    return (older_invoices.order_by("number").values_list("number", flat=True).last() or 0) + 1
 
 
 class AbstractInvoice(BaseMixin, models.Model):


### PR DESCRIPTION
`values(...).last()` returns a dict, on which `getattr` doesn't work, so `get_initial_number` always returned 1 instead of the highest `Invoice.number`