### PR TITLE
Throttle autorenew

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ django-plans changelog
 ------------------
 * Support for Python 3.9 - 3.13
 * Remove support for Django 4.2 - 5.2
+* Add ``--throttle`` parameter to the ``autorenew_accounts`` management command
 
 1.2.0
 ------------------

--- a/plans/management/commands/autorenew_accounts.py
+++ b/plans/management/commands/autorenew_accounts.py
@@ -13,11 +13,20 @@ class Command(BaseCommand):
             dest="providers",
             help="Renew only accounts with this providers",
         )
+        parser.add_argument(
+            "--throttle",
+            type=int,
+            dest="throttle",
+            help="Throttle seconds between renewals",
+        )
 
     def handle(self, *args, **options):  # pragma: no cover
         providers = options.get("providers")
         self.stdout.write("Starting renewal")
-        renewed_accounts = tasks.autorenew_account(providers)
+        throttle_seconds = options.get("throttle")
+        renewed_accounts = tasks.autorenew_account(
+            providers, throttle_seconds=throttle_seconds
+        )
         if renewed_accounts:
             self.stdout.write("Accounts submitted to renewal:")
             for a in renewed_accounts:

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import time
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -19,7 +20,7 @@ def get_active_plans():
     )
 
 
-def autorenew_account(providers=None):
+def autorenew_account(providers=None, throttle_seconds=0):
     logger.info("Started automatic account renewal")
     PLANS_AUTORENEW_BEFORE_DAYS = getattr(settings, "PLANS_AUTORENEW_BEFORE_DAYS", 0)
     PLANS_AUTORENEW_BEFORE_HOURS = getattr(settings, "PLANS_AUTORENEW_BEFORE_HOURS", 0)
@@ -41,6 +42,8 @@ def autorenew_account(providers=None):
     logger.info(f"{len(accounts_for_renewal)} accounts to be renewed.")
 
     for user in accounts_for_renewal.all():
+        if throttle_seconds:
+            time.sleep(throttle_seconds)
         account_automatic_renewal.send(sender=None, user=user)
     return accounts_for_renewal
 


### PR DESCRIPTION
[autorenew_accounts: add possibility to throttle between renewals](https://github.com/django-getpaid/django-plans/commit/54a61223de84c4f2ad384fd62f17576ce328283b)