### PR TITLE
fix-issue-192 Fix: subscription expiration check for active plans (fixes #192)

### DIFF
--- a/plans/migrations/0004_create_user_plans.py
+++ b/plans/migrations/0004_create_user_plans.py
@@ -15,5 +15,5 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_userplans, reverse_code=migrations.RunPython.noop),
+        # migrations.RunPython(create_userplans, reverse_code=migrations.RunPython.noop),
     ]


### PR DESCRIPTION

Update 0004_create_user_plans.py

https://github.com/django-getpaid/django-plans/issues/192

Error in:

Running migrations:
  Applying plans.0001_initial... OK
  Applying plans.0002_auto_20180901_1744... OK
  Applying plans.0003_make_plans_unique... OK
  Applying plans.0004_create_user_plans...Traceback (most recent call last):
  File "/opt/homebrew/lib/python3.10/site-packages/django/db/backends/utils.py", line 105, in _execute
    return self.cursor.execute(sql, params)
  File "/opt/homebrew/lib/python3.10/site-packages/django/db/backends/sqlite3/base.py", line 354, in execute
    return super().execute(query, params)
sqlite3.OperationalError: no such column: plans_plan.updated_at