### PR TITLE
fix: add select_for_update on UserPlan in complete_order and return_o…

### DIFF
--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -919,6 +919,14 @@ class AbstractOrder(BaseMixin, models.Model):
         )
 
         if order.completed is None:
+            # Lock the UserPlan row to serialize concurrent modifications
+            # (e.g. multiple payments for the same user processed simultaneously).
+            # Without this, concurrent transactions read stale expire/plan values,
+            # causing extensions not to stack and refunds to over-subtract.
+            AbstractUserPlan.get_concrete_model().objects.select_for_update().get(
+                user=self.user
+            )
+            self.user.userplan.refresh_from_db()
             self.plan_extended_from = self.get_plan_extended_from()
             status = self.user.userplan.extend_account(self.plan, self.pricing)
             self.plan_extended_until = self.user.userplan.expire
@@ -933,6 +941,7 @@ class AbstractOrder(BaseMixin, models.Model):
         else:
             return False
 
+    @transaction.atomic()
     def return_order(self):
         if self.status != self.STATUS.RETURNED:
             if self.status == self.STATUS.COMPLETED:
@@ -953,6 +962,10 @@ class AbstractOrder(BaseMixin, models.Model):
                             f"plan_extended_until={self.plan_extended_until}, "
                             f"pricing.period={self.pricing.period}"
                         )
+                AbstractUserPlan.get_concrete_model().objects.select_for_update().get(
+                    user=self.user
+                )
+                self.user.userplan.refresh_from_db()
                 self.user.userplan.reduce_account(self.pricing)
             elif self.status != self.STATUS.NOT_VALID:
                 raise ValueError(

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -983,6 +983,139 @@ class ConcurrentTestInvoice(TransactionTestCase):
             self.assertEqual(Invoice.objects.count(), 1)
 
 
+class ConcurrentCompleteOrderTest(TransactionTestCase):
+    """Verify that concurrent complete_order/return_order calls for the same
+    user correctly serialize via select_for_update, so extensions stack and
+    reductions subtract the right amount."""
+
+    fixtures = ["initial_plan", "test_django-plans_auth", "test_django-plans_plans"]
+
+    @staticmethod
+    def _complete_order_in_thread(order_id, results, index):
+        """Thread target: complete an order and close the DB connection."""
+        try:
+            order = Order.objects.get(id=order_id)
+            order.complete_order()
+            results[index] = True
+        except Exception as e:
+            results[index] = e
+        finally:
+            from django.db import connection
+
+            connection.close()
+
+    @staticmethod
+    def _return_order_in_thread(order_id, results, index):
+        try:
+            order = Order.objects.get(id=order_id)
+            order.return_order()
+            results[index] = True
+        except Exception as e:
+            results[index] = e
+        finally:
+            from django.db import connection
+
+            connection.close()
+
+    def test_concurrent_complete_order_stacks_expire(self):
+        import threading
+
+        u = User.objects.get(username="test1")
+        u.userplan.expire = now().date() + timedelta(days=50)
+        u.userplan.save()
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+
+        order_ids = []
+        for _ in range(3):
+            order = Order.objects.create(
+                user=u,
+                pricing=plan_pricing.pricing,
+                amount=100,
+                plan=plan_pricing.plan,
+            )
+            order_ids.append(order.id)
+
+        results = [None] * 3
+        threads = [
+            threading.Thread(
+                target=self._complete_order_in_thread, args=(oid, results, i)
+            )
+            for i, oid in enumerate(order_ids)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        for i, r in enumerate(results):
+            if isinstance(r, Exception):
+                raise r
+            self.assertTrue(r, f"Thread {i} did not complete")
+
+        u.userplan.refresh_from_db()
+        self.assertEqual(
+            u.userplan.expire,
+            now().date() + timedelta(days=50 + 30 * 3),
+        )
+        self.assertEqual(
+            Order.objects.filter(
+                id__in=order_ids, status=Order.STATUS.COMPLETED
+            ).count(),
+            3,
+        )
+
+    def test_concurrent_return_order_reduces_correctly(self):
+        """Complete 3 orders sequentially, return 2 concurrently — expire
+        should reflect only the remaining 1 extension."""
+        import threading
+
+        u = User.objects.get(username="test1")
+        u.userplan.expire = now().date() + timedelta(days=50)
+        u.userplan.save()
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+
+        orders = []
+        for _ in range(3):
+            order = Order.objects.create(
+                user=u,
+                pricing=plan_pricing.pricing,
+                amount=100,
+                plan=plan_pricing.plan,
+            )
+            order.complete_order()
+            orders.append(order)
+
+        u.userplan.refresh_from_db()
+        self.assertEqual(
+            u.userplan.expire,
+            now().date() + timedelta(days=50 + 30 * 3),
+        )
+
+        results = [None] * 2
+        threads = [
+            threading.Thread(
+                target=self._return_order_in_thread,
+                args=(orders[i + 1].id, results, i),
+            )
+            for i in range(2)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        for i, r in enumerate(results):
+            if isinstance(r, Exception):
+                raise r
+            self.assertTrue(r, f"Thread {i} did not complete")
+
+        u.userplan.refresh_from_db()
+        self.assertEqual(
+            u.userplan.expire,
+            now().date() + timedelta(days=50 + 30),
+        )
+
+
 class OrderTestCase(TestCase):
     fixtures = ["initial_plan", "test_django-plans_auth", "test_django-plans_plans"]
 


### PR DESCRIPTION
…rder

When multiple payments for the same user are processed concurrently (e.g. duplicate payment webhooks arriving simultaneously), the extend_account/reduce_account methods read stale UserPlan state because each transaction hasn't committed yet (PostgreSQL READ COMMITTED).

This causes:
- Extensions not stacking (all read the same pre-commit expire value)
- Refunds over-subtracting (removing time that was never effectively added)

The fix acquires a row lock on UserPlan via select_for_update() before reading and modifying expire/plan fields, serializing concurrent access per-user. Different users are unaffected (different rows = no contention).

Also wraps return_order in @transaction.atomic() to ensure the lock is properly scoped.

Made-with: Cursor