### PR TITLE
fix: shift later orders' extension windows on mid-chain refund [Invoice/order payment mismatches]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,12 @@
 django-plans changelog
 ======================
 
+unreleased
+----------
+
+* **Bug Fixes**: Fixed ``Order.return_order`` leaving stale ``plan_extended_from``/``plan_extended_until`` on completed orders stacked after the returned one. A mid-chain refund (e.g. a yearly order refunded after a monthly order already extended past it) correctly rewound ``UserPlan.expire``, but later orders kept describing the pre-refund timeline — breaking the invariant that ``expire`` equals the last completed order's ``plan_extended_until``, and misleading downstream consumers that schedule period-based processing by those dates. ``reduce_account`` now shifts each later completed order's window back by the same delta the refund removed from ``expire``. Durations are preserved, so later orders remain refundable themselves. Refunding the newest order, full unwinds to the pre-order state, and legacy orders without ``plan_extended_until`` are unaffected.
+* **Tests**: Added regression tests for the mid-chain window shift (standard and fresh-start deltas) and a guard that refunding the newest order leaves earlier orders' windows untouched.
+
 2.3.0
 -----
 

--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -468,6 +468,43 @@ class AbstractUserPlan(BaseMixin, models.Model):
 
         return status
 
+    def _shift_orders_stacked_after(self, order, expire_before_reduction):
+        """Slide later stacked orders' windows back after a mid-chain refund.
+
+        Returning an order rewinds ``expire``, but completed orders stacked
+        on top of the returned one still describe the pre-refund timeline:
+        their ``plan_extended_from``/``plan_extended_until`` cover days the
+        user no longer owns. Those dates are load-bearing - host apps
+        schedule period-based processing (e.g. creator revenue distribution)
+        by them, and ``expire`` should equal the last completed order's
+        ``plan_extended_until``. Shift each later order's window back by
+        exactly the delta the refund removed from ``expire``. Durations are
+        preserved, so ``return_order``'s from/until sanity check still holds
+        if a later order is refunded afterwards.
+        """
+        if order is None or order.plan_extended_until is None:
+            return
+        if expire_before_reduction is None or self.expire is None:
+            return
+        delta = expire_before_reduction - self.expire
+        if delta <= timedelta(0):
+            return
+        later_orders = (
+            order.__class__.objects.filter(
+                user=self.user,
+                status=order.STATUS.COMPLETED,
+                plan_extended_from__gte=order.plan_extended_until,
+            )
+            .exclude(pk=order.pk)
+            .exclude(plan_extended_until=None)
+        )
+        for later_order in later_orders:
+            later_order.plan_extended_from -= delta
+            later_order.plan_extended_until -= delta
+            later_order.save(
+                update_fields=["plan_extended_from", "plan_extended_until"]
+            )
+
     def reduce_account(self, pricing, order=None):
         """
         Manages reducing account after returning an order
@@ -485,6 +522,12 @@ class AbstractUserPlan(BaseMixin, models.Model):
             ``plan`` is also restored so a refunded first purchase doesn't
             leave the user on a paid plan with ``expire=None``.
 
+            Completed orders stacked after the returned one get their
+            ``plan_extended_from``/``plan_extended_until`` shifted back by
+            the same delta the refund removed from ``expire``, so their
+            windows keep describing the days they actually cover (see
+            ``_shift_orders_stacked_after``).
+
             For backward compatibility with orders completed before the
             snapshot fields existed (and for callers that don't have an
             order, like tests of the raw API), ``order=None`` keeps the
@@ -493,6 +536,7 @@ class AbstractUserPlan(BaseMixin, models.Model):
         """
         if pricing is None:
             return
+        expire_before_reduction = self.expire
         if order is not None and order.userplan_active_before is not None:
             # Snapshot path: rewind by the actual extension delta so the
             # refund is symmetric with what extend_account did, even when
@@ -551,9 +595,11 @@ class AbstractUserPlan(BaseMixin, models.Model):
             else:
                 self.active = self.expire >= now().date()
             self.save()
+            self._shift_orders_stacked_after(order, expire_before_reduction)
             return
         self.expire = self.get_plan_reduced_until(pricing)
         self.save()
+        self._shift_orders_stacked_after(order, expire_before_reduction)
 
     def expire_account(self):
         """manages account expiration"""

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -1822,6 +1822,183 @@ class OrderTestCase(TestCase):
         self.assertIsNone(u.userplan.expire)
         self.assertFalse(u.userplan.active)
 
+    def test_return_order_mid_chain_shifts_later_order_window(self):
+        """Refunding an older order must slide later stacked orders'
+        plan_extended_from/until back by the refunded delta, so the
+        invariant ``expire == last completed order's plan_extended_until``
+        survives a mid-chain refund. Without the shift, the later order
+        keeps describing days the user no longer owns - and host apps that
+        schedule period-based processing by those dates work on a window
+        that no longer exists."""
+        u = User.objects.get(username="test1")
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+        u.userplan.expire = now().date() + timedelta(days=10)
+        u.userplan.active = True
+        u.userplan.save()
+
+        order_first = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_first.complete_order()
+        order_then = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_then.complete_order()
+        order_then_from = order_then.plan_extended_from
+        order_then_until = order_then.plan_extended_until
+
+        order_first.return_order()
+
+        order_then.refresh_from_db()
+        self.assertEqual(
+            order_then.plan_extended_from, order_then_from - timedelta(days=30)
+        )
+        self.assertEqual(
+            order_then.plan_extended_until, order_then_until - timedelta(days=30)
+        )
+        # Duration is preserved, so ``order_then`` itself stays refundable
+        # (return_order asserts until - from == pricing.period).
+        u.userplan.refresh_from_db()
+        self.assertEqual(u.userplan.expire, order_then.plan_extended_until)
+        # The refunded order's own window is untouched - it documents what
+        # the order did when it completed.
+        order_first.refresh_from_db()
+        self.assertEqual(
+            order_first.plan_extended_until - order_first.plan_extended_from,
+            timedelta(days=30),
+        )
+
+    def test_return_order_mid_chain_shifts_by_fresh_start_delta(self):
+        """The shift uses the actual rewound delta, not pricing.period:
+        a fresh-start order that extended out of an expired state removed
+        more than pricing.period days, and the later order must slide by
+        exactly that amount."""
+        u = User.objects.get(username="test1")
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+        previous_expire = now().date() - timedelta(days=13)
+        u.userplan.expire = previous_expire
+        u.userplan.active = False
+        u.userplan.save()
+
+        order_fresh_start = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_fresh_start.complete_order()
+        order_continuation = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_continuation.complete_order()
+        continuation_until = order_continuation.plan_extended_until
+
+        order_fresh_start.return_order()
+
+        # The fresh start added 43 days (today+30 minus today-13); the
+        # continuation order slides back by the same 43.
+        order_continuation.refresh_from_db()
+        self.assertEqual(
+            order_continuation.plan_extended_until,
+            continuation_until - timedelta(days=43),
+        )
+        u.userplan.refresh_from_db()
+        self.assertEqual(u.userplan.expire, order_continuation.plan_extended_until)
+
+    def test_return_order_last_order_leaves_earlier_windows_alone(self):
+        """Refunding the newest order must not touch earlier orders'
+        windows - only orders stacked *after* the returned one shift."""
+        u = User.objects.get(username="test1")
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+        u.userplan.expire = now().date() + timedelta(days=10)
+        u.userplan.active = True
+        u.userplan.save()
+
+        order_first = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_first.complete_order()
+        order_then = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_then.complete_order()
+        order_first_from = order_first.plan_extended_from
+        order_first_until = order_first.plan_extended_until
+
+        order_then.return_order()
+
+        order_first.refresh_from_db()
+        self.assertEqual(order_first.plan_extended_from, order_first_from)
+        self.assertEqual(order_first.plan_extended_until, order_first_until)
+        u.userplan.refresh_from_db()
+        self.assertEqual(u.userplan.expire, order_first.plan_extended_until)
+
+    def test_return_order_corrupt_snapshot_never_shifts_later_orders_forward(self):
+        """A corrupt snapshot can make the rewind delta non-positive: here
+        ``userplan_expire_before`` was recorded *after* the order's own
+        ``plan_extended_until``, so the standard rewind computes negative
+        extension_days and expire grows on refund. Applying that delta to
+        later orders would shift their windows forward into days that were
+        never bought - the shift must be skipped instead."""
+        u = User.objects.get(username="test1")
+        plan_pricing = PlanPricing.objects.get(plan=u.userplan.plan, pricing__period=30)
+        u.userplan.expire = now().date() + timedelta(days=10)
+        u.userplan.active = True
+        u.userplan.save()
+
+        order_first = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_first.complete_order()
+        order_then = Order.objects.create(
+            user=u,
+            pricing=plan_pricing.pricing,
+            amount=100,
+            plan=plan_pricing.plan,
+            status=Order.STATUS.NEW,
+        )
+        order_then.complete_order()
+        order_then_from = order_then.plan_extended_from
+        order_then_until = order_then.plan_extended_until
+
+        # Corrupt the snapshot: pretend the pre-order expire was later than
+        # the extension the order recorded.
+        order_first.userplan_expire_before = (
+            order_first.plan_extended_until + timedelta(days=10)
+        )
+        order_first.save()
+
+        order_first.return_order()
+
+        order_then.refresh_from_db()
+        self.assertEqual(order_then.plan_extended_from, order_then_from)
+        self.assertEqual(order_then.plan_extended_until, order_then_until)
+
     def test_return_order_isolated_none_before_restores_none(self):
         """Single order extending out of expire=None: refund must
         restore expire to None and active to the pre-order snapshot."""


### PR DESCRIPTION
## Problem

`Order.return_order()` rewinds `UserPlan.expire` correctly (via the snapshot logic from 2.1.9/2.3.0), but completed orders stacked **after** the returned one keep their pre-refund `plan_extended_from`/`plan_extended_until`.

Timeline of a mid-chain refund:

| When | Event | expire |
|---|---|---|
| Jul 15 | Order A completes, records "extended Jul 15 → Aug 15" | Aug 15 |
| Jul 15 | Order B completes, records "extended Aug 15 → Sep 15" | Sep 15 |
| Jul 22 | **Order A refunded** | Aug 15 ✓ |

After the refund, order B still says "I extended the plan until Sep 15" — a timeline that no longer exists. That permanently breaks the invariant `expire == last completed order's plan_extended_until`, and misleads downstream consumers that schedule period-based processing by those dates (e.g. creator revenue distribution keyed on the order's window: in one production case at Blendkit the distribution for the later order was parked more than a year in the future, sampling a month in which the user has no subscription).

Mid-chain refunds are legitimate and cannot be forbidden: support refunds the expensive earlier order when a yearly and a monthly are stacked (observed in production), and gateway refunds/chargebacks are bound to a specific old transaction.

## Fix

`reduce_account()` now shifts each later completed order's window back by **exactly the delta the refund removed from `expire`** — computed uniformly as `expire_before_reduction − expire`, which covers:

- the standard snapshot rewind (`extension_days`),
- the larger fresh-start delta (order completed against an expired plan),
- the legacy `pricing.period` fallback for orders without a snapshot.

Durations are preserved, so `return_order`'s `until − from == pricing.period` sanity check still holds if a later order is refunded afterwards. Unaffected: refunding the newest order (nothing is stacked after it), full unwinds to the pre-order `expire=None` state (by branch condition no later order exists), and orders without `plan_extended_until`.

No migration — the change only writes to existing fields.

## Tests

- `test_return_order_mid_chain_shifts_later_order_window` — the timeline above; fails on master with the later order's window one month in the future.
- `test_return_order_mid_chain_shifts_by_fresh_start_delta` — the shift uses the actual 43-day fresh-start delta, not `pricing.period`; fails on master.
- `test_return_order_last_order_leaves_earlier_windows_alone` — LIFO refund guard, passes before and after (no over-shifting).
- `test_return_order_corrupt_snapshot_never_shifts_later_orders_forward` — a corrupt snapshot yielding a non-positive rewind delta must not shift later orders *forward*; covers the delta guard (100% patch coverage).
- Full suite: `Ran 206 tests ... OK (skipped=1)` on Django 5.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
