### PR TITLE
fix: business dates use the active time zone's date, not the UTC date [Pre-vacation error review]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,13 @@ django-plans changelog
 unreleased
 ----------
 
+* **Fix**: business-date calculations used ``timezone.now().date()`` -- the
+  UTC date -- instead of the active time zone's date. For any time zone with
+  an offset there is a nightly window in which plan expiry checks,
+  ``days_left``, account extension anchors, the ``expire_account`` task and
+  invoice issue dates were off by one day (issue #236). All twelve call
+  sites now use ``timezone.localdate()``.
+
 * **Fix**: ``autorenew_account`` retried the same account several times per
   scheduled slot when the task ran more often than daily: the renewal window
   coerced the expiration date through the current time zone while the

--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -22,7 +22,7 @@ from django.template import Context
 from django.template.base import Template
 from django.urls import reverse
 from django.utils import translation
-from django.utils.timezone import now
+from django.utils.timezone import localdate, now
 from django.utils.translation import gettext_lazy as _
 from django.utils.translation import pgettext_lazy
 from django_countries.fields import CountryField
@@ -251,13 +251,13 @@ class AbstractUserPlan(BaseMixin, models.Model):
         if self.expire is None:
             return False
         else:
-            return self.expire < now().date()
+            return self.expire < localdate()
 
     def days_left(self):
         if self.expire is None:
             return None
         else:
-            return (self.expire - now().date()).days
+            return (self.expire - localdate()).days
 
     def clean_activation(self):
         errors = plan_validation(self.user)
@@ -297,7 +297,7 @@ class AbstractUserPlan(BaseMixin, models.Model):
             return None
         if not self.is_expired() and self.expire is not None and self.plan == plan:
             return self.expire
-        return now().date()
+        return localdate()
 
     def has_automatic_renewal(self):
         return (
@@ -430,7 +430,7 @@ class AbstractUserPlan(BaseMixin, models.Model):
                 # but just in case we consider a case when user has a different plan
                 if not self.plan.is_free() and self.expire is None:
                     status = True
-                elif not self.plan.is_free() and self.expire > now().date():
+                elif not self.plan.is_free() and self.expire > localdate():
                     status = False
                     accounts_logger.warning(
                         "Account '%s' [id=%d] plan NOT changed to '%s' [id=%d]"
@@ -593,7 +593,7 @@ class AbstractUserPlan(BaseMixin, models.Model):
             if self.expire is None:
                 self.active = order.userplan_active_before
             else:
-                self.active = self.expire >= now().date()
+                self.active = self.expire >= localdate()
             self.save()
             self._shift_orders_stacked_after(order, expire_before_reduction)
             return
@@ -994,7 +994,7 @@ class AbstractOrder(BaseMixin, models.Model):
     # the exact same number of days that were added, which is the only way
     # to undo extensions that started from an expired (or ``None``) state:
     # in those cases ``extend_account`` advances ``expire`` to
-    # ``now().date() + pricing.period`` rather than
+    # ``localdate() + pricing.period`` rather than
     # ``previous_expire + pricing.period`` -> a naive
     # ``expire -= pricing.period`` rewind would land *later* than where the
     # plan was before the order, leaving stale paid-plan time the user no
@@ -1112,7 +1112,7 @@ class AbstractOrder(BaseMixin, models.Model):
             # extension added. extend_account/reduce_account are otherwise
             # asymmetric for plans that were expired (or had expire=None) at
             # completion time: extend_account jumps expire forward to
-            # ``now().date() + pricing.period`` instead of
+            # ``localdate() + pricing.period`` instead of
             # ``previous_expire + pricing.period``, while reduce_account
             # always rewinds by exactly ``pricing.period`` days.
             self.userplan_expire_before = self.user.userplan.expire
@@ -1549,7 +1549,7 @@ class AbstractInvoice(BaseMixin, models.Model):
         except BillingInfo.DoesNotExist:
             return
 
-        day = now().date()
+        day = localdate()
         pday = order.completed
         if invoice_type == cls.INVOICE_TYPES["PROFORMA"]:
             pday = day + timedelta(days=14)
@@ -1622,7 +1622,7 @@ class AbstractInvoice(BaseMixin, models.Model):
         # Copy data from original invoice
         credit_note.user = self.user
         credit_note.order = self.order
-        credit_note.issued = now().date()
+        credit_note.issued = localdate()
         credit_note.payment_date = (
             self.payment_date
         )  # Use original invoice's payment_date
@@ -1669,7 +1669,7 @@ class AbstractInvoice(BaseMixin, models.Model):
             credit_note_for=self,
             user=self.user,
             order=self.order,
-            issued=now().date(),
+            issued=localdate(),
             payment_date=self.payment_date,  # Use original invoice's payment_date
             selling_date=self.selling_date,
             quantity=1,

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -169,7 +169,7 @@ def expire_account():
     logger.info("Started account expiration")
 
     expired_accounts = get_active_plans().filter(
-        userplan__expire__lt=timezone.now().date()
+        userplan__expire__lt=timezone.localdate()
     )
 
     for user in expired_accounts.all():
@@ -179,7 +179,7 @@ def expire_account():
 
     if notifications_days_before:
         days = map(
-            lambda x: timezone.now().date() + datetime.timedelta(days=x),
+            lambda x: timezone.localdate() + datetime.timedelta(days=x),
             notifications_days_before,
         )
         for user in User.objects.select_related("userplan").filter(

--- a/plans/tests/test_business_dates.py
+++ b/plans/tests/test_business_dates.py
@@ -1,0 +1,62 @@
+import datetime
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase, override_settings
+from freezegun import freeze_time
+from model_bakery import baker
+
+from plans.base.models import AbstractRecurringUserPlan
+from plans.models import RecurringUserPlan
+from plans.tasks import expire_account
+
+User = get_user_model()
+
+
+@override_settings(TIME_ZONE="America/New_York")
+@freeze_time("2026-08-05 02:00:00")  # UTC is Aug 5; New York is still Aug 4, 22:00
+class BusinessDatesUseTheActiveTimezoneTests(TestCase):
+    """Business-date arithmetic must use the active time zone's date.
+
+    ``timezone.now().date()`` is the UTC date; for any time zone behind UTC
+    there is a nightly window in which UTC has moved to the next day while
+    the active time zone has not, and every "is it expired yet?" style
+    calculation flips a day early (issue #236 -- the mirror image of the
+    autorenew slot bug, which hit time zones ahead of UTC).
+    """
+
+    def setUp(self):
+        self.user = baker.make(User, username="tz_user", email="tz@example.com")
+        self.plan = baker.make("Plan", name="Test Plan")
+        self.pricing = baker.make("Pricing", period=30)
+        baker.make("PlanPricing", plan=self.plan, pricing=self.pricing, price=10)
+        # Expires "today" in New York -- still valid for two more local hours.
+        self.user_plan = baker.make(
+            "UserPlan",
+            user=self.user,
+            plan=self.plan,
+            expire=datetime.date(2026, 8, 4),
+            active=True,
+        )
+
+    def test_plan_expiring_today_is_not_expired_yet(self):
+        self.assertFalse(self.user_plan.is_expired())
+
+    def test_days_left_counts_from_the_local_date(self):
+        self.assertEqual(self.user_plan.days_left(), 0)
+
+    def test_expire_account_does_not_expire_a_day_early(self):
+        baker.make(
+            RecurringUserPlan,
+            user_plan=self.user_plan,
+            renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+            token_verified=True,
+            pricing=self.pricing,
+            amount=Decimal(10),
+            currency="USD",
+        )
+
+        expire_account()
+
+        self.user_plan.refresh_from_db()
+        self.assertTrue(self.user_plan.active)

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -2899,34 +2899,34 @@ class TasksTestCase(TestCase):
 
 
 class TimezoneConsistencyTestCase(TestCase):
-    """Regression tests for date.today() vs timezone.now().date() bug.
+    """Regression tests for the business-date clock.
 
-    When USE_TZ=True and the system timezone differs from UTC, date.today()
-    returns the local date while timezone.now().date() returns the UTC date.
-    Near midnight UTC these can differ by one day, causing incorrect plan
-    expiry checks, days_left calculations, and extension logic.
+    Two wrong clocks have shipped historically: date.today() (the server's
+    system-local date, fixed in 2.1.5) and timezone.now().date() (the UTC
+    date, wrong for any active time zone with an offset -- issue #236). The
+    correct clock is timezone.localdate(), the date in the active time zone;
+    plans/tests/test_business_dates.py pins its behavior at a real UTC/local
+    boundary.
 
-    Fixed in 2.1.5: all date calculations now use timezone.now().date().
-
-    These tests mock timezone.now() to return a date far from today. If the
-    code accidentally used date.today() instead, it would return the actual
-    current date and the assertions would fail.
+    These tests mock localdate() to return a date far from today. If the
+    code regressed to either wrong clock, it would return the actual current
+    date and the assertions would fail.
     """
 
-    @patch("plans.base.models.now", return_value=datetime(2020, 1, 15, 12, 0, 0))
-    def test_is_expired_uses_timezone_now(self, mock_now):
+    @patch("plans.base.models.localdate", return_value=date(2020, 1, 15))
+    def test_is_expired_uses_localdate(self, mock_localdate):
         up = baker.make("UserPlan", expire=date(2020, 1, 15))
         self.assertFalse(up.is_expired())
         up.expire = date(2020, 1, 14)
         self.assertTrue(up.is_expired())
 
-    @patch("plans.base.models.now", return_value=datetime(2020, 1, 15, 12, 0, 0))
-    def test_days_left_uses_timezone_now(self, mock_now):
+    @patch("plans.base.models.localdate", return_value=date(2020, 1, 15))
+    def test_days_left_uses_localdate(self, mock_localdate):
         up = baker.make("UserPlan", expire=date(2020, 1, 25))
         self.assertEqual(up.days_left(), 10)
 
-    @patch("plans.base.models.now", return_value=datetime(2020, 1, 15, 12, 0, 0))
-    def test_get_plan_extended_from_uses_timezone_now(self, mock_now):
+    @patch("plans.base.models.localdate", return_value=date(2020, 1, 15))
+    def test_get_plan_extended_from_uses_localdate(self, mock_localdate):
         plan = baker.make("Plan")
         pricing = baker.make("Pricing", period=30)
         baker.make("PlanPricing", plan=plan, pricing=pricing, price=Decimal("10.00"))
@@ -2935,8 +2935,8 @@ class TimezoneConsistencyTestCase(TestCase):
         self.assertEqual(extended_from, date(2020, 1, 15))
 
     @override_settings(PLANS_SEND_EMAILS_PLAN_EXTENDED=False)
-    @patch("plans.base.models.now", return_value=datetime(2020, 1, 15, 12, 0, 0))
-    def test_extend_account_uses_timezone_now(self, mock_now):
+    @patch("plans.base.models.localdate", return_value=date(2020, 1, 15))
+    def test_extend_account_uses_localdate(self, mock_localdate):
         plan = baker.make("Plan")
         pricing = baker.make("Pricing", period=30)
         baker.make("PlanPricing", plan=plan, pricing=pricing, price=Decimal("10.00"))

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -176,7 +176,9 @@ class PlansTestCase(TestCase):
         self.assertEqual(u.userplan.active, True)
         self.assertEqual(len(mail.outbox), 1)
 
-    @freeze_time("2012-01-14")
+    # Noon, not midnight: midnight UTC is still the previous day in the
+    # test time zone (America/Chicago), and business dates read the local day.
+    @freeze_time("2012-01-14 12:00:00")
     def test_extend_account_other_expire_none(self):
         """
         Tests extending expired=None account with other Plan that user had before and is expired:
@@ -763,7 +765,7 @@ class TestInvoice(TestCase):
         self.assertEqual(invoice.payment_date, original_payment_date)
 
         # Cancel the invoice (create credit note) on a different date
-        with freeze_time("2024-02-20"):
+        with freeze_time("2024-02-20 12:00:00"):
             credit_note = invoice.cancel_invoice(reason="Test cancellation")
 
         # Credit note should use original invoice's payment_date, not today's date
@@ -803,7 +805,7 @@ class TestInvoice(TestCase):
         self.assertEqual(invoice.payment_date, original_payment_date)
 
         # Create partial credit note on a different date
-        with freeze_time("2024-03-10"):
+        with freeze_time("2024-03-10 12:00:00"):
             credit_note = invoice.create_partial_credit_note(
                 net_amount=Decimal("30.00"),
                 tax_amount=Decimal("6.00"),
@@ -1417,7 +1419,7 @@ class OrderTestCase(TestCase):
             plan=plan_pricing_then.plan,
             status=Order.STATUS.NEW,
         )
-        with freeze_time(datetime.combine(u.userplan.expire, time())):
+        with freeze_time(datetime.combine(u.userplan.expire, time(12))):
             order_then.complete_order()
 
         order.return_order()


### PR DESCRIPTION
## Issue #236, confirmed and fixed at every call site

`timezone.now().date()` is the **UTC date**. For any active time zone with an offset there is a nightly window in which UTC has moved to the next day while the active time zone has not (or vice versa), and every business-date calculation flips by one day. #236 reported exactly this — test failures that appeared only during certain hours, then vanished.

It is also the mirror image of the autorenew slot bug just merged (#240): that one hit time zones **ahead** of UTC through SQL-side date arithmetic; this one hits any offset through Python-side `now().date()`. Same disease — reading a business date off the wrong clock — completing the same cleanup.

**Twelve call sites swept** to `timezone.localdate()`:

- `UserPlan.is_expired`, `days_left`, `expire_date` anchor, `extend_account` comparison, `activate/deactivate` flag (`base/models.py`)
- invoice `issued` dates (2×) and the invoice day anchor (`base/models.py`)
- `expire_account` filter and its notification-day windows (`tasks.py`)

## Tests

New `plans/tests/test_business_dates.py` pins the contract at a real boundary — frozen at 02:00 UTC with `TIME_ZONE="America/New_York"` (local clock still on the previous day):

- a plan expiring "today" is **not** expired yet (was: expired two local hours early),
- `days_left` counts from the local date (was: off by one),
- `expire_account` does not deactivate a day early (was: it did).

All three red before the sweep. `TimezoneConsistencyTestCase` — which pinned the 2.1.5-era `timezone.now().date()` contract — now mocks `localdate()` and keeps its original regression purpose against **both** historical wrong clocks (`date.today()` and the UTC date); its docstring tells the two-stage history.

Full suite locally: 97 passed, failures identical to virgin master in my environment (demo-app fixtures/templates, unrelated). Lint clean.

## Release note

Together with #240 this makes the upcoming release a coherent "the calendar has one clock" release. Behavior shift to call out: users in TZs behind UTC gain up to `|offset|` hours of plan validity they were previously robbed of; invoice `issued` dates near midnight UTC now reflect the operator's local date.
