### PR TITLE
test: pin the untested task contracts; run the suite without Postgres [Pre-vacation error review]

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -24,6 +24,11 @@ tox -e py311-django
 
 See [tox.ini](tox.ini).
 
+To run the suite without a local PostgreSQL server (a handful of
+concurrency/constraint tests are expected to fail on SQLite):
+
+
+
 You can also run the tests manually in `demo/` dir (presumably using `venv`):
 
 ```

--- a/demo/example/settings_sqlite.py
+++ b/demo/example/settings_sqlite.py
@@ -1,0 +1,20 @@
+"""Test settings for running the suite without a PostgreSQL server.
+
+CI runs the real matrix against PostgreSQL; this module exists so that
+manage.py test works on a bare checkout:
+
+    DJANGO_SETTINGS_MODULE=example.settings_sqlite PYTHONPATH=demo \
+        python demo/manage.py test plans
+
+The concurrency test cases and length-constraint assertions need a real
+PostgreSQL and are expected to fail on SQLite.
+"""
+
+from example.settings import *  # noqa: F401,F403
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": ":memory:",
+    }
+}

--- a/plans/tests/test_task_contracts.py
+++ b/plans/tests/test_task_contracts.py
@@ -97,9 +97,10 @@ class AutorenewDryRunTests(TestCase):
     def setUp(self):
         self.user = _renewable_user("dryrun", datetime.date(2026, 8, 6))
         self.signals = []
-        receiver = lambda sender, user, **kwargs: self.signals.append(
-            user
-        )  # noqa: E731
+
+        def receiver(sender, user, **kwargs):
+            self.signals.append(user)
+
         account_automatic_renewal.connect(receiver)
         self.addCleanup(account_automatic_renewal.disconnect, receiver)
 

--- a/plans/tests/test_task_contracts.py
+++ b/plans/tests/test_task_contracts.py
@@ -1,0 +1,204 @@
+import datetime
+from decimal import Decimal
+
+from django.contrib.auth import get_user_model
+from django.core import mail
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from freezegun import freeze_time
+from model_bakery import baker
+
+from plans.base.models import AbstractRecurringUserPlan
+from plans.models import RecurringUserPlan
+from plans.signals import account_automatic_renewal
+from plans.tasks import autorenew_account, expire_account
+
+User = get_user_model()
+
+
+def _renewable_user(username, expire):
+    user = baker.make(User, username=username, email=f"{username}@example.com")
+    plan = baker.make("Plan", name=f"Plan {username}")
+    pricing = baker.make("Pricing", period=30)
+    baker.make("PlanPricing", plan=plan, pricing=pricing, price=10)
+    user_plan = baker.make("UserPlan", user=user, plan=plan, expire=expire, active=True)
+    baker.make(
+        RecurringUserPlan,
+        user_plan=user_plan,
+        renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+        token_verified=True,
+        pricing=pricing,
+        amount=Decimal(10),
+        currency="USD",
+    )
+    return user
+
+
+@override_settings(PLANS_AUTORENEW_SCHEDULE=[datetime.timedelta(days=1)])
+@freeze_time("2026-08-05 12:00:00")
+class AutorenewFailureIsolationTests(TestCase):
+    """One account's failing charge must not decide the whole batch's fate.
+
+    In production the renewal signal talks to a payment provider; a provider
+    exception for one customer is routine. The batch semantics around it are
+    load-bearing and were untested: with ``catch_exceptions`` the remaining
+    accounts must still renew and admins must hear about the failure; without
+    it (the default) the failure must stay loud.
+    """
+
+    def setUp(self):
+        expires_tomorrow = datetime.date(2026, 8, 6)
+        self.failing = _renewable_user("failing", expires_tomorrow)
+        self.healthy = _renewable_user("healthy", expires_tomorrow)
+        self.renewed = []
+
+        def receiver(sender, user, **kwargs):
+            if user == self.failing:
+                raise RuntimeError("provider declined in a novel way")
+            self.renewed.append(user)
+
+        account_automatic_renewal.connect(receiver)
+        self.addCleanup(account_automatic_renewal.disconnect, receiver)
+
+    @override_settings(ADMINS=[("Admin", "admin@example.com")])
+    def test_catch_exceptions_isolates_the_failure(self):
+        attempted = autorenew_account(catch_exceptions=True)
+
+        self.assertIn(self.healthy, self.renewed)
+        self.assertIn(self.failing, attempted)
+        admin_mail = [m for m in mail.outbox if "Failed to renew" in m.subject]
+        self.assertEqual(len(admin_mail), 1)
+        self.assertIn(str(self.failing.pk), admin_mail[0].body)
+
+    def test_catch_exceptions_still_records_the_failed_attempt(self):
+        # Deliberate contract: a crashed charge consumes the slot too --
+        # otherwise a frequently scheduled task hammers the failing card
+        # until the slot closes.
+        autorenew_account(catch_exceptions=True)
+
+        self.failing.userplan.recurring.refresh_from_db()
+        self.assertIsNotNone(self.failing.userplan.recurring.last_renewal_attempt)
+
+    def test_default_lets_the_failure_propagate(self):
+        with self.assertRaises(RuntimeError):
+            autorenew_account()
+
+
+@override_settings(PLANS_AUTORENEW_SCHEDULE=[datetime.timedelta(days=1)])
+@freeze_time("2026-08-05 12:00:00")
+class AutorenewDryRunTests(TestCase):
+    """``dry_run`` exists so operators can preview a charge batch safely.
+
+    A dry run that mutated bookkeeping would either charge nobody forever
+    (slots consumed) or charge everyone twice (attempts untracked); a dry
+    run that sent the signal would charge cards from a "safe" command.
+    """
+
+    def setUp(self):
+        self.user = _renewable_user("dryrun", datetime.date(2026, 8, 6))
+        self.signals = []
+        receiver = lambda sender, user, **kwargs: self.signals.append(
+            user
+        )  # noqa: E731
+        account_automatic_renewal.connect(receiver)
+        self.addCleanup(account_automatic_renewal.disconnect, receiver)
+
+    def test_dry_run_reports_but_touches_nothing(self):
+        candidates = autorenew_account(dry_run=True)
+
+        self.assertIn(self.user, candidates)
+        self.assertEqual(self.signals, [])
+        self.user.userplan.recurring.refresh_from_db()
+        self.assertIsNone(self.user.userplan.recurring.last_renewal_attempt)
+
+    def test_dry_run_does_not_consume_the_slot(self):
+        autorenew_account(dry_run=True)
+        attempted = autorenew_account()
+
+        self.assertIn(self.user, attempted)
+        self.assertEqual(self.signals, [self.user])
+
+
+@freeze_time("2026-08-05 12:00:00")
+class ExpirationReminderTests(TestCase):
+    """``PLANS_EXPIRATION_REMIND`` drives the pre-expiry warning emails.
+
+    The windows were swept to local dates in the #236 fix with no test
+    pinning them: a reminder must fire exactly on the configured
+    days-before, not a day early or late.
+    """
+
+    def _user_expiring_in(self, days):
+        return _renewable_user(
+            f"expiring{days}", timezone.localdate() + datetime.timedelta(days=days)
+        )
+
+    @override_settings(PLANS_EXPIRATION_REMIND=[3])
+    def test_reminder_fires_exactly_on_the_configured_day(self):
+        self._user_expiring_in(3)
+
+        expire_account()
+
+        reminders = [m for m in mail.outbox if "expir" in m.subject.lower()]
+        self.assertEqual(len(reminders), 1)
+
+    @override_settings(PLANS_EXPIRATION_REMIND=[3])
+    def test_no_reminder_on_neighboring_days(self):
+        self._user_expiring_in(2)
+        self._user_expiring_in(4)
+
+        expire_account()
+
+        self.assertEqual(mail.outbox, [])
+
+
+class AutorenewCalendarEdgeTests(TestCase):
+    """Slot bookkeeping edges: DST transitions and the max-age boundary."""
+
+    def _attempts_at(self, user, *instants):
+        attempts = []
+        for instant in instants:
+            with freeze_time(instant):
+                attempts.append(sum(1 for u in autorenew_account() if u == user))
+        return attempts
+
+    @override_settings(
+        PLANS_AUTORENEW_SCHEDULE=[datetime.timedelta(days=1, hours=3)],
+        TIME_ZONE="Europe/Prague",
+    )
+    def test_dst_transition_day_still_attempts_exactly_once(self):
+        # Prague springs forward on 2026-03-29: the local day is 23 hours
+        # long. Calendar-date slot bookkeeping must not skip or double the
+        # attempt around the jump.
+        user = _renewable_user("dst", datetime.date(2026, 3, 30))
+
+        attempts = self._attempts_at(
+            user,
+            "2026-03-28 19:01:00",
+            "2026-03-28 20:01:00",
+            "2026-03-29 05:01:00",
+            "2026-03-29 21:01:00",
+        )
+
+        self.assertEqual(sum(attempts), 1, attempts)
+
+    @override_settings(
+        PLANS_AUTORENEW_SCHEDULE=[datetime.timedelta(days=-1)],
+        PLANS_AUTORENEW_MAX_DAYS_AFTER_EXPIRY=datetime.timedelta(days=30),
+    )
+    @freeze_time("2026-08-05 12:00:00")
+    def test_max_days_after_expiry_boundary_is_day_exact(self):
+        # The -1d slot's window reaches back exactly 30 days; the day-31
+        # account must be left alone. Off-by-one here either abandons
+        # recoverable accounts or charges cards a month after churn.
+        included = _renewable_user(
+            "included", timezone.localdate() - datetime.timedelta(days=31)
+        )
+        excluded = _renewable_user(
+            "excluded", timezone.localdate() - datetime.timedelta(days=32)
+        )
+
+        attempted = autorenew_account()
+
+        self.assertIn(included, attempted)
+        self.assertNotIn(excluded, attempted)


### PR DESCRIPTION
## Nine tests for load-bearing, zero-covered contracts

Follow-up to #240/#241, answering "which tests are actually worth adding": every test here pins behavior that production depends on and that had **no coverage at all** (`catch_exceptions`, `dry_run`, `PLANS_EXPIRATION_REMIND`: zero mentions in the suite before this).

**Failure isolation** (`AutorenewFailureIsolationTests`) — the renewal signal talks to a payment provider; one customer's provider exception is routine, and the batch semantics around it were untested:
- with `catch_exceptions=True`, the remaining accounts still renew, admins get mailed with the failing user's id, and the failed attempt **still consumes its slot** — deliberate and now stated in a test: a crashed charge that kept its slot open would hammer the failing card on every task run;
- the default stays loud: without the flag the exception propagates.

**Dry run** (`AutorenewDryRunTests`) — an operator preview must be inert in both directions: it sends no signal, records no attempt, consumes no slot (a follow-up real run still attempts). A dry run that mutated bookkeeping would either charge nobody forever or charge everyone twice.

**Expiration reminders** (`ExpirationReminderTests`) — `PLANS_EXPIRATION_REMIND` windows were swept to local dates in #241 with nothing pinning them: the reminder fires exactly on the configured days-before, and not on neighboring days.

**Calendar edges** (`AutorenewCalendarEdgeTests`):
- Prague spring-forward (23-hour local day): slot bookkeeping neither skips nor doubles the attempt;
- `PLANS_AUTORENEW_MAX_DAYS_AFTER_EXPIRY` is day-exact — day-31 attempted, day-32 left alone. Off-by-one here either abandons recoverable accounts or charges cards a month after churn.

## Developer experience: suite runs without Postgres

`example.settings_sqlite` + a DEVELOPMENT.md note make `manage.py test plans` work on a bare checkout (this is how these tests were developed). The concurrency and varchar-constraint cases legitimately require PostgreSQL and are documented as expected SQLite failures — CI remains the Postgres judge.

## Results

CI-style local run: **221 tests** (212 + 9 new), failures identical to master's SQLite baseline (2F/3E, all backend-specific). Lint clean.

## Noted, deliberately not included

While writing these I looked for an autorenew *concurrency* test (two overlapping task runs can both pass the filter before either records the attempt — a plausible mechanism for same-slot double charges). `ConcurrentCompleteOrderTest` shows the suite can express this against Postgres, but a test would today pin a race that loses; the honest sequence is a fix (atomic claim of the attempt, e.g. conditional `UPDATE … WHERE last_renewal_attempt IS NULL OR <slot condition>` before sending the signal) landing together with its test. Separate PR if wanted.
