### PR TITLE
fix(demo): loadable example fixture, honest installation instructions [Pre-vacation error review]

### DIFF
--- a/demo/example/foo/fixtures/initial_data.json
+++ b/demo/example/foo/fixtures/initial_data.json
@@ -63,7 +63,8 @@
       "default": true,
       "customized": null,
       "order": 0,
-      "name": "Standard"
+      "name": "Standard",
+      "slug": "standard"
     }
   },
   {
@@ -74,10 +75,11 @@
       "visible": true,
       "description": "Most recommended",
       "created": "2012-05-05T15:36:31Z",
-      "default": false,
+      "default": null,
       "customized": null,
       "order": 1,
-      "name": "Premium"
+      "name": "Premium",
+      "slug": "premium"
     }
   },
   {
@@ -88,10 +90,11 @@
       "visible": true,
       "description": "Professional plan",
       "created": "2012-07-12T13:07:23Z",
-      "default": false,
+      "default": null,
       "customized": null,
       "order": 2,
-      "name": "PRO"
+      "name": "PRO",
+      "slug": "pro"
     }
   },
   {
@@ -102,10 +105,11 @@
       "visible": true,
       "description": "Custom for test1",
       "created": "2012-07-12T17:33:30.112Z",
-      "default": false,
+      "default": null,
       "customized": 1,
       "order": 4,
-      "name": "Custom"
+      "name": "Custom",
+      "slug": "custom"
     }
   },
   {
@@ -116,10 +120,11 @@
       "visible": true,
       "description": "Custom test 2",
       "created": "2012-07-24T12:51:57.438Z",
-      "default": false,
+      "default": null,
       "customized": 2,
       "order": 5,
-      "name": "Custom 2"
+      "name": "Custom 2",
+      "slug": "custom-2"
     }
   },
   {

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -60,15 +60,14 @@ Optionally create virtual environment and get required packages to run example p
     $ pip install -r requirements.txt
 
 
-Initialize example project database:
+Initialize the example project database and load the example data (the
+demo is configured for PostgreSQL; if you don't have one running, see
+``DEVELOPMENT.md`` for the SQLite test settings):
 
 .. code-block:: bash
 
-    $ cd ..
     $ python manage.py migrate
-
-
-Initial example data will be loaded automatically.
+    $ python manage.py loaddata initial_data
 
 
 Create `UserPlan` objects for all `User` objects:


### PR DESCRIPTION
## The demo has been broken for a fresh checkout since at least 2023 (#178)

Three stacked breakages, each verified by actually walking the installation docs on a bare clone:

1. **The docs point away from `manage.py`** (`cd ..` out of `demo/`) and claim the example data "will be loaded automatically" — automatic `initial_data` loading left Django in 1.7.
2. With that fixed, **`loaddata` dies on `plans_plan.slug`**: the fixture predates the slug field, so every plan collides on the same generated value.
3. Next, **`plans_plan.default`**: a unique-nullable boolean — the four non-default plans must be `null` ("Unknown"), not `false`, exactly as the model's own `help_text` documents. (This is also the error shape of long-open #97.)

## Change

- Fixture: distinct slug per plan, `null` for non-defaults — a 23-line surgical diff, original formatting preserved.
- `docs/source/installation.rst`: the commands that actually work (`migrate` + `loaddata initial_data` from `demo/`), plus a pointer to the SQLite test settings in DEVELOPMENT.md (arriving in #242) for readers without PostgreSQL.

Verified end-to-end on a fresh database: 5 plans (1 default), 2 users, 2 userplans.

## Housekeeping this enables

- **#178** closes with this PR.
- **#186** (Fix django-plans demo) can then be closed as superseded with thanks: its `--catch-exceptions`, CI action bumps, and suds→zeep are all in master already; its demo-SQLite goal is covered by `example.settings_sqlite` (#242) without giving up PostgreSQL parity in CI; its fixture concern is resolved here.
