### PR TITLE
fix: claim each renewal attempt atomically against concurrent runs [Pre-vacation error review]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@ django-plans changelog
 unreleased
 ----------
 
+* **Fix**: two overlapping ``autorenew_account`` runs could both select the
+  same account before either recorded its attempt, charging it twice. Each
+  attempt is now claimed with an atomic compare-and-swap on
+  ``last_renewal_attempt``; the losing run skips the account without
+  touching the payment provider.
+
 * **Fix**: business-date calculations used ``timezone.now().date()`` -- the
   UTC date -- instead of the active time zone's date. For any time zone with
   an offset there is a nightly window in which plan expiry checks,

--- a/plans/tasks.py
+++ b/plans/tasks.py
@@ -36,6 +36,27 @@ def _slot_open_day_delta(schedule):
     return math.ceil(schedule / datetime.timedelta(days=1))
 
 
+def _claim_renewal_attempt(recurring):
+    """Atomically claim one renewal attempt against concurrent task runs.
+
+    Two overlapping runs can both select the same account before either
+    records its attempt -- and then both charge. The claim is a
+    compare-and-swap: record the attempt only if ``last_renewal_attempt``
+    still holds the value this run selected. A single conditional UPDATE is
+    atomic on every backend, so exactly one run wins; the loser skips the
+    account without touching the payment provider.
+    """
+    model = type(recurring)
+    unchanged = model.objects.filter(pk=recurring.pk)
+    if recurring.last_renewal_attempt is None:
+        unchanged = unchanged.filter(last_renewal_attempt__isnull=True)
+    else:
+        unchanged = unchanged.filter(
+            last_renewal_attempt=recurring.last_renewal_attempt
+        )
+    return bool(unchanged.update(last_renewal_attempt=timezone.now()))
+
+
 def autorenew_account(
     providers=None, throttle_seconds=0, catch_exceptions=False, dry_run=False
 ):
@@ -137,8 +158,12 @@ def autorenew_account(
     renewed_accounts = []
     for user in accounts_for_renewal:
         if hasattr(user, "userplan") and hasattr(user.userplan, "recurring"):
-            user.userplan.recurring.last_renewal_attempt = timezone.now()
-            user.userplan.recurring.save(update_fields=["last_renewal_attempt"])
+            if not _claim_renewal_attempt(user.userplan.recurring):
+                logger.info(
+                    f"Renewal of user {user.pk} already claimed by a concurrent "
+                    "run, skipping"
+                )
+                continue
         if throttle_seconds:
             time.sleep(throttle_seconds)
         if catch_exceptions:

--- a/plans/tests/test_autorenew_schedule.py
+++ b/plans/tests/test_autorenew_schedule.py
@@ -8,6 +8,7 @@ from freezegun import freeze_time
 from model_bakery import baker
 
 from plans.models import AbstractRecurringUserPlan, RecurringUserPlan
+from plans.signals import account_automatic_renewal
 from plans.tasks import autorenew_account
 
 User = get_user_model()
@@ -348,3 +349,94 @@ class AutorenewSlotBookkeepingTests(TestCase):
         )
 
         self.assertEqual(attempts, [1, 0, 0, 0])
+
+
+class AutorenewConcurrentClaimTests(TestCase):
+    """Overlapping task runs must charge each account at most once.
+
+    Two runs can both select the same account before either records its
+    attempt; whichever writes first must win and the other must skip. The
+    claim is a compare-and-swap on ``last_renewal_attempt``: it only
+    records the attempt if the field still holds the value the run selected,
+    which is atomic on every backend as a single conditional UPDATE.
+    """
+
+    def setUp(self):
+        self.user = baker.make(User, username="claimed", email="claimed@example.com")
+        self.plan = baker.make("Plan", name="Test Plan")
+        self.pricing = baker.make("Pricing", period=30)
+        baker.make("PlanPricing", plan=self.plan, pricing=self.pricing, price=10)
+        self.user_plan = baker.make(
+            "UserPlan",
+            user=self.user,
+            plan=self.plan,
+            expire=datetime.date(2026, 8, 6),
+        )
+        baker.make(
+            RecurringUserPlan,
+            user_plan=self.user_plan,
+            renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+            token_verified=True,
+            pricing=self.pricing,
+            amount=Decimal(10),
+            currency="USD",
+        )
+
+    def _snapshot(self):
+        # A concurrent run's view of the row: read independently, as its
+        # queryset would.
+        return RecurringUserPlan.objects.get(pk=self.user_plan.recurring.pk)
+
+    def test_stale_snapshot_loses_the_claim(self):
+        from plans.tasks import _claim_renewal_attempt
+
+        first_run = self._snapshot()
+        second_run = self._snapshot()
+
+        self.assertTrue(_claim_renewal_attempt(first_run))
+        self.assertFalse(_claim_renewal_attempt(second_run))
+
+    def test_claim_also_races_correctly_on_a_later_slot(self):
+        from plans.tasks import _claim_renewal_attempt
+
+        previous = timezone.now() - datetime.timedelta(days=2)
+        RecurringUserPlan.objects.filter(pk=self.user_plan.recurring.pk).update(
+            last_renewal_attempt=previous
+        )
+
+        first_run = self._snapshot()
+        second_run = self._snapshot()
+
+        self.assertTrue(_claim_renewal_attempt(first_run))
+        self.assertFalse(_claim_renewal_attempt(second_run))
+
+    @override_settings(PLANS_AUTORENEW_SCHEDULE=[datetime.timedelta(days=1)])
+    @freeze_time("2026-08-05 12:00:00")
+    def test_lost_claim_skips_the_signal(self):
+        signals = []
+
+        def receiver(sender, user, **kwargs):
+            signals.append(user)
+
+        account_automatic_renewal.connect(receiver)
+        self.addCleanup(account_automatic_renewal.disconnect, receiver)
+
+        # Simulate the overlapping run winning between this run's selection
+        # and its claim: the selection sees the account, the claim must not.
+        from plans import tasks as tasks_module
+
+        original_claim = tasks_module._claim_renewal_attempt
+
+        def racing_claim(recurring):
+            RecurringUserPlan.objects.filter(pk=recurring.pk).update(
+                last_renewal_attempt=timezone.now()
+            )
+            return original_claim(recurring)
+
+        tasks_module._claim_renewal_attempt = racing_claim
+        self.addCleanup(setattr, tasks_module, "_claim_renewal_attempt", original_claim)
+
+        attempted = autorenew_account()
+
+        self.assertEqual(signals, [])
+        self.assertEqual(attempted, [])


### PR DESCRIPTION
## The last unguarded double-charge mechanism in the renewal task

`autorenew_account` selects due accounts, then records each attempt — two separate steps. Two overlapping runs (a scheduler firing before the previous run finished, or two schedulers) can both select the same account in that window, and both charge it.

Honest scoping from production data (blenderkit.com): with hourly scheduling since April we found **zero** task-created attempt pairs under 45 minutes — the task never actually overlapped itself there. This PR is a structural guard, not a response to an observed incident: requested because the renewal path moves money and its correctness should not depend on scheduler discipline. (What production *did* show — 5k+ human-path rapid retries — is an application-side issue, being fixed separately in the application.)

## The fix

Replace the blind save with a **compare-and-swap claim**: a single conditional `UPDATE` records `last_renewal_attempt` only if it still holds the value this run selected.

```python
unchanged = model.objects.filter(pk=..., last_renewal_attempt=<value this run saw>)
claimed = unchanged.update(last_renewal_attempt=timezone.now())
```

One `UPDATE` is atomic on every backend, so exactly one run wins; the loser logs and skips the account **without touching the payment provider**. No locks, no transactions spanning the provider call, no new fields or settings.

## Tests (red before the fix)

`AutorenewConcurrentClaimTests` drives the race deterministically rather than probabilistically:

- two independent snapshots of the same row claim in turn — the stale one loses (fresh-account and later-slot variants);
- end-to-end: a simulated concurrent winner landing *between selection and claim* results in **no renewal signal at all** for this run.

Autorenew suites: 18 passed. Compatible with the slot-bookkeeping semantics from #240 (the claim happens where the recording always did, before the signal — a crashed charge still consumes its slot, as pinned in #242's contract tests).
