### PR TITLE
fix: normalize Plan.default False to NULL, ending the unique crash [Pre-vacation error review]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,11 @@ unreleased
   ``last_renewal_attempt``; the losing run skips the account without
   touching the payment provider.
 
+* **Fix**: saving a second plan with default="No" crashed with a bare
+  IntegrityError -- ``Plan.default`` is unique-nullable and False means the
+  same as NULL ("Unknown"). False is now normalized to NULL on save, and
+  migration 0020 normalizes the at-most-one stored False (issue #97).
+
 * **Fix**: business-date calculations used ``timezone.now().date()`` -- the
   UTC date -- instead of the active time zone's date. For any time zone with
   an offset there is a nightly window in which plan expiry checks,

--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -116,6 +116,15 @@ class AbstractPlan(BaseMixin, OrderedModel):
         verbose_name = _("Plan")
         verbose_name_plural = _("Plans")
 
+    def save(self, *args, **kwargs):
+        # ``default`` is unique-nullable: True at most once, and False means
+        # the same as NULL ("Unknown") per the field's help_text -- but two
+        # stored Falses violate the unique constraint with a bare
+        # IntegrityError (issue #97). Normalize so False is never stored.
+        if self.default is False:
+            self.default = None
+        return super().save(*args, **kwargs)
+
     @classmethod
     def get_default_plan(cls):
         try:

--- a/plans/migrations/0020_normalize_non_default_plans.py
+++ b/plans/migrations/0020_normalize_non_default_plans.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def false_to_null(apps, schema_editor):
+    Plan = apps.get_model("plans", "Plan")
+    Plan.objects.filter(default=False).update(default=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("plans", "0019_order_userplan_plan_before"),
+    ]
+
+    operations = [
+        # False and NULL both mean "not the default plan" (see the field's
+        # help_text), but the unique constraint tolerates only one stored
+        # False. At most one row can exist with default=False, so this
+        # touches at most one row; reverse is a no-op because NULL already
+        # meant the same thing.
+        migrations.RunPython(false_to_null, migrations.RunPython.noop),
+    ]

--- a/plans/tests/test_default_plan_flag.py
+++ b/plans/tests/test_default_plan_flag.py
@@ -1,0 +1,38 @@
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+from model_bakery import baker
+
+from plans.models import Plan
+
+
+class DefaultPlanFlagTests(TestCase):
+    """``Plan.default`` is unique-nullable: True at most once, everything
+    else must be stored as NULL ("Unknown").
+
+    The admin offers "No" (False) as a choice, but storing False twice
+    violates the unique constraint and greeted the second save with a bare
+    IntegrityError (issue #97). False and NULL mean the same thing -- the
+    field's own help_text says so -- so False is normalized to NULL on save.
+    """
+
+    def test_two_non_default_plans_save_without_error(self):
+        a = baker.make("Plan", name="A", default=False)
+        b = baker.make("Plan", name="B", default=False)
+
+        a.refresh_from_db()
+        b.refresh_from_db()
+        self.assertIsNone(a.default)
+        self.assertIsNone(b.default)
+
+    def test_the_single_default_survives_normalization(self):
+        plan = baker.make("Plan", name="D", default=True)
+
+        plan.refresh_from_db()
+        self.assertTrue(plan.default)
+
+    def test_second_default_fails_loud_but_friendly(self):
+        baker.make("Plan", name="D1", default=True)
+        second = Plan(name="D2", default=True)
+
+        with self.assertRaises(ValidationError):
+            second.full_clean()


### PR DESCRIPTION
## Issue #97: the second "No" crashes

`Plan.default` is unique-nullable: `True` marks the single default plan, and the field's own help_text declares `False` ("No") and `NULL` ("Unknown") synonyms — *"Both 'Unknown' and 'No' means that the plan is not default."* But the unique constraint tolerates only one stored `False`, so the second plan saved with default="No" — a perfectly reasonable admin choice — dies with a bare `IntegrityError`. Empirically reconfirmed: the demo fixture reproduced exactly this crash before #243.

## Fix

Since `False` and `NULL` are declared synonyms, never store `False`: `AbstractPlan.save()` normalizes it to `NULL`. Migration 0020 normalizes existing data (at most **one** row can hold `False`, so it touches at most one row; reverse is a documented no-op).

Duplicate `default=True` keeps its existing friendly path — unique validation in `full_clean()`/forms — pinned by a test rather than changed.

## Tests (red-first)

- two plans saved with `default=False` both persist as `NULL`, no error (**was: IntegrityError**);
- the single `default=True` survives normalization untouched;
- a second `default=True` still fails via `ValidationError`, not `IntegrityError`.

Full CI-style suite: 224 tests, failures identical to the SQLite baseline (backend-specific concurrency/constraint cases). Lint clean.
