### PR TITLE
fix: sargable invoice-numbering filters (date ranges, not __year/__month) [Pre-vacation error review]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,14 @@ unreleased
   crashed on save with an IntegrityError. ``currency`` is now nullable
   (migration 0021): a disarmed renewal has no currency.
 
+* **Fix**: monthly/annual invoice numbering filtered older invoices with
+  ``issued__year``/``issued__month`` -- extraction lookups the planner
+  cannot serve from the index on ``issued``, so on large invoice tables
+  the ``MAX(number)`` probe degraded to scanning the whole table (or the
+  whole ``number`` index backwards) inside the invoice-save transaction.
+  Plain date-range predicates keep the exact same semantics and let the
+  planner use the existing ``issued`` index.
+
 2.4.0
 -----
 

--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -1419,13 +1419,24 @@ class AbstractInvoice(BaseMixin, models.Model):
                 older_invoices = older_invoices.filter(issued=self.issued)
             elif invoice_counter_reset == Invoice.NUMBERING.MONTHLY:
                 invoice_counter_value = f"{self.issued.year}_{self.issued.month}"
+                # Range predicates instead of __year/__month: the extraction
+                # lookups are not sargable, so on a large invoice table the
+                # planner walked the `number` index backwards (get_initial_number
+                # orders by number) reading the whole table instead of using
+                # the index on `issued`.
+                month_start = self.issued.replace(day=1)
+                next_month_start = (month_start + timedelta(days=31)).replace(day=1)
                 older_invoices = older_invoices.filter(
-                    issued__year=self.issued.year,
-                    issued__month=self.issued.month,
+                    issued__gte=month_start,
+                    issued__lt=next_month_start,
                 )
             elif invoice_counter_reset == Invoice.NUMBERING.ANNUALLY:
                 invoice_counter_value = f"{self.issued.year}"
-                older_invoices = older_invoices.filter(issued__year=self.issued.year)
+                year_start = self.issued.replace(month=1, day=1)
+                older_invoices = older_invoices.filter(
+                    issued__gte=year_start,
+                    issued__lt=year_start.replace(year=year_start.year + 1),
+                )
             elif callable(invoice_counter_reset):
                 invoice_counter_value, initial_number = invoice_counter_reset(self)
                 invoice_counter_reset_name = "call"


### PR DESCRIPTION
## Problem

Monthly/annual invoice numbering filters older invoices with `issued__year=...`/`issued__month=...`. `EXTRACT()` predicates cannot use the b-tree index that already exists on `issued`, so `get_initial_number()`'s `MAX(number)` probe has no good plan on a large invoice table — and it runs inside the invoice-save transaction.

Measured on a synthetic 700k-row table with the stock single-column indexes (`issued`, `number`):

| Case | `__year/__month` (before) | date range (after) |
|---|---|---|
| sparse type+month | parallel **seq scan, 700k rows filtered**, 26 ms | index scan on `issued`, ~9k rows, **2.3 ms** |
| dense recent month | backward walk of the `number` index (~60% of the table), 156 ms | 82 ms (accurate row estimates) |

On BlenderKit production this exact pattern tripped statement timeouts on payment endpoints (700k-row invoice table) and had to be worked around via the `PLANS_INVOICE_COUNTER_RESET` callable; this fixes it for every installation.

## Fix

Replace the extraction lookups with equivalent half-open date ranges (`issued >= period start AND issued < next period start`) for MONTHLY and ANNUALLY. Same rows, same numbering semantics — but the planner can use the existing `issued` index. DAILY already used a plain equality.

## Testing

No new tests: numbering semantics across period boundaries are already covered by the existing DAILY/MONTHLY/ANNUALLY tests, and the full `plans` suite matches the master baseline exactly. The perf claim is verified by the EXPLAIN ANALYZE measurements above rather than by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
