### PR TITLE
fix(taxation): retry transient VIES faults with backoff, extract validate_vies hook [Káje questions in #ucetnictvi]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,22 @@
 django-plans changelog
 ======================
 
+unreleased
+----------
+
+* **Fix**: transient VIES faults (``MS_MAX_CONCURRENT_REQ``,
+  ``GLOBAL_MAX_CONCURRENT_REQ``, ``MS_UNAVAILABLE``,
+  ``SERVICE_UNAVAILABLE``, ``TIMEOUT``) are retried with exponential
+  backoff instead of immediately falling back to the last-known tax.
+  Renewal batches fire many VIES checks in a short window and trip the
+  member states' concurrency limits (384 such faults in one production's
+  90-day Sentry window); the throttle clears in seconds, so a retry
+  usually recovers the check. Deterministic faults are not retried.
+* **New**: the live check is extracted into an overridable
+  ``EUTaxationPolicy.validate_vies(tax_id)`` classmethod, so projects can
+  plug in a cached/stored validation source (e.g. a nightly-validated
+  VAT ID table with VIES consultation numbers).
+
 2.5.1
 -----
 

--- a/plans/taxation/eu.py
+++ b/plans/taxation/eu.py
@@ -1,4 +1,5 @@
 import logging
+import time
 from decimal import Decimal
 from urllib.error import URLError
 from xml.sax import SAXParseException
@@ -122,6 +123,47 @@ class EUTaxationPolicy(TaxationPolicy):
             "EUTaxationPolicy requires that issuer country is in EU"
         )
 
+    # Seconds-scale VIES throttling/outage codes worth retrying; anything
+    # else (e.g. INVALID_INPUT) is deterministic and retries are useless.
+    VIES_TRANSIENT_FAULTS = (
+        "MS_MAX_CONCURRENT_REQ",
+        "GLOBAL_MAX_CONCURRENT_REQ",
+        "MS_UNAVAILABLE",
+        "SERVICE_UNAVAILABLE",
+        "TIMEOUT",
+    )
+    VIES_RETRY_ATTEMPTS = 3
+    VIES_RETRY_DELAY = 2  # seconds, doubled after each attempt
+
+    @classmethod
+    def validate_vies(cls, tax_id):
+        """Live VIES registry check with backoff on transient faults.
+
+        Renewal batches fire many checks in a short window and trip the
+        member states' concurrency limits; those faults clear in seconds.
+        Overridable to plug in a cached/stored validation source.
+        """
+        for attempt in range(cls.VIES_RETRY_ATTEMPTS):
+            try:
+                return bool(stdnum.eu.vat.check_vies(tax_id)["valid"])
+            except Fault as fault:
+                transient = any(
+                    code in str(fault) for code in cls.VIES_TRANSIENT_FAULTS
+                )
+                if not transient or attempt == cls.VIES_RETRY_ATTEMPTS - 1:
+                    raise
+                delay = cls.VIES_RETRY_DELAY * 2**attempt
+                logger.warning(
+                    "Transient VIES fault for TAX_ID=%s (attempt %s/%s), "
+                    "retrying in %ss: %s",
+                    tax_id,
+                    attempt + 1,
+                    cls.VIES_RETRY_ATTEMPTS,
+                    delay,
+                    fault,
+                )
+                time.sleep(delay)
+
     @classmethod
     def get_tax_rate(cls, tax_id, country_code, request=None):
         """
@@ -164,7 +206,7 @@ class EUTaxationPolicy(TaxationPolicy):
             if cls.is_in_EU(country_code):
                 # Company is from other EU country
                 try:
-                    vies_result = bool(stdnum.eu.vat.check_vies(tax_id)["valid"])
+                    vies_result = cls.validate_vies(tax_id)
                     logger.info("TAX_ID=%s RESULT=%s" % (tax_id, vies_result))
                     if tax_id and vies_result:
                         # Company is registered in VIES

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -2237,6 +2237,54 @@ class EUTaxationPolicyTestCase(TestCase):
             self.assertEqual(rate, Decimal("19.0"))
             self.assertFalse(success)  # Indicates fallback was used
 
+    @mock.patch("plans.taxation.eu.time.sleep")
+    @mock.patch("stdnum.eu.vat.check_vies")
+    def test_vies_transient_fault_retried(self, mock_check, mock_sleep):
+        """
+        MS_MAX_CONCURRENT_REQ is a seconds-scale VIES throttle: a renewal
+        batch fires many checks at once and the member state rejects some.
+        The check must be retried with backoff instead of falling back.
+        """
+        from zeep.exceptions import Fault
+
+        mock_check.side_effect = [
+            Fault("MS_MAX_CONCURRENT_REQ"),
+            Fault("MS_MAX_CONCURRENT_REQ"),
+            {"valid": True},
+        ]
+        with self.settings(PLANS_TAX=Decimal("23.0"), PLANS_TAX_COUNTRY="PL"):
+            self.assertEqual(
+                self.policy.get_tax_rate("AT123456789", "AT"), (None, True)
+            )
+        self.assertEqual(mock_check.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    @mock.patch("plans.taxation.eu.time.sleep")
+    @mock.patch("stdnum.eu.vat.check_vies")
+    def test_vies_transient_fault_exhausted_falls_back(self, mock_check, mock_sleep):
+        from zeep.exceptions import Fault
+
+        mock_check.side_effect = Fault("GLOBAL_MAX_CONCURRENT_REQ")
+        with self.settings(PLANS_TAX=Decimal("23.0"), PLANS_TAX_COUNTRY="PL"):
+            rate, success = self.policy.get_tax_rate("AT123456789", "AT")
+        self.assertEqual(rate, Decimal("20.0"))
+        self.assertFalse(success)
+        self.assertEqual(mock_check.call_count, 3)
+
+    @mock.patch("plans.taxation.eu.time.sleep")
+    @mock.patch("stdnum.eu.vat.check_vies")
+    def test_vies_non_transient_fault_not_retried(self, mock_check, mock_sleep):
+        """An INVALID_INPUT fault is deterministic - retrying is useless."""
+        from zeep.exceptions import Fault
+
+        mock_check.side_effect = Fault("INVALID_INPUT")
+        with self.settings(PLANS_TAX=Decimal("23.0"), PLANS_TAX_COUNTRY="PL"):
+            rate, success = self.policy.get_tax_rate("AT123456789", "AT")
+        self.assertEqual(rate, Decimal("20.0"))
+        self.assertFalse(success)
+        self.assertEqual(mock_check.call_count, 1)
+        mock_sleep.assert_not_called()
+
 
 class BillingInfoTestCase(TestCase):
     def test_clean_tax_number(self):


### PR DESCRIPTION
## Why

Renewal batches fire many VIES checks in a short window and trip the member states' concurrency limits. One production instance shows **384 `Fault: MS_MAX_CONCURRENT_REQ` events over 90 days**, clustered exactly in the nightly renewal hours (72 % of faults in the 19:00–01:00 UTC window matching the renewal bursts). Each fault makes `get_tax_rate` fall back — on renewals that keeps the last-known tax (`use_default=False`), so a company whose VAT ID was deregistered can keep reverse charge for months because the re-check that would catch it keeps erroring out.

## What

- Transient VIES faults (`MS_MAX_CONCURRENT_REQ`, `GLOBAL_MAX_CONCURRENT_REQ`, `MS_UNAVAILABLE`, `SERVICE_UNAVAILABLE`, `TIMEOUT`) are retried up to 3× with exponential backoff (2 s/4 s) — these throttles clear in seconds. Deterministic faults (e.g. `INVALID_INPUT`) are not retried.
- The live check is extracted into an overridable `EUTaxationPolicy.validate_vies(tax_id)` classmethod, so projects can plug in a cached/stored validation source (e.g. a nightly-validated VAT ID table storing VIES consultation numbers for audit safe-harbor proof) without copying `get_tax_rate`.

## Tests

TDD: three new tests (retry-then-succeed, retries-exhausted fallback, non-transient not retried) failed on master first; `EUTaxationPolicyTestCase` now 15/15. black/isort clean; no new flake8 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)