### PR TITLE
Keep an armed renewal on the right terms across a plan change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,19 @@
 django-plans changelog
 ======================
 
+Unreleased
+----------
+
+* **Fix**: a plan change (``UserPlan.extend_account(plan, pricing=None)``)
+  now re-points an armed ``RecurringUserPlan`` at the new plan's
+  ``PlanPricing`` for the period it already renews on. Previously the
+  account kept renewing at the price of the plan it had left.
+* **Fix**: ``UserPlan.set_plan_renewal()`` called with a plan-change order
+  (one without a pricing) keeps the subscription's own pricing, amount, tax
+  and currency and only takes the token-related values. Copying the change
+  order left the renewal with ``pricing=None`` and the one-off difference as
+  its amount - a subscription that renewed nothing.
+
 2.6.0 (2026-08-25)
 ------------------
 

--- a/plans/base/models.py
+++ b/plans/base/models.py
@@ -379,21 +379,68 @@ class AbstractUserPlan(BaseMixin, models.Model):
                 else self.recurring.RENEWAL_TRIGGERED_BY.USER
             )
 
+        # A plan-change order carries no pricing (see ``extend_account``): it
+        # changes the plan, not how the account renews. Copying its fields
+        # would leave an armed renewal with ``pricing=None`` and the one-off
+        # difference as its amount - a subscription that renews nothing.
+        # Keep the subscription's own terms and only take the token-related
+        # values the caller passes in ``kwargs``.
+        keep_terms = order.pricing is None and self.recurring.pricing_id is not None
+        if keep_terms:
+            terms = {
+                "pricing": self.recurring.pricing,
+                "amount": self.recurring.amount,
+                "tax": self.recurring.tax,
+                "currency": self.recurring.currency,
+            }
+
         # Erase values of all fields
         # We don't want to mix the old and new values
         self.recurring.set_all_fields_default()
 
         # Set new values
         self.recurring.user_plan = self
-        self.recurring.pricing = order.pricing
-        self.recurring.amount = order.amount
-        self.recurring.tax = order.tax
-        self.recurring.currency = order.currency
+        if keep_terms:
+            for field, value in terms.items():
+                setattr(self.recurring, field, value)
+        else:
+            self.recurring.pricing = order.pricing
+            self.recurring.amount = order.amount
+            self.recurring.tax = order.tax
+            self.recurring.currency = order.currency
         self.recurring.renewal_triggered_by = renewal_triggered_by
         for k, v in kwargs.items():
             setattr(self.recurring, k, v)
         self.recurring.save()
         return self.recurring
+
+    def _reprice_recurring_for_plan(self, plan):
+        """Point an armed renewal at ``plan``'s price for the period it renews on.
+
+        A plan change keeps the billing period (the ``Pricing`` row) and only
+        swaps the plan, so the renewal must bill the new plan's ``PlanPricing``
+        for that same period from now on. Without this the account kept
+        renewing at the price of the plan it left. Nothing is done when the
+        new plan does not sell that period; the ``account_change_plan``
+        signal fires right after and lets projects apply their own policy.
+        """
+        recurring = getattr(self, "recurring", None)
+        if recurring is None or recurring.pricing_id is None:
+            return
+        plan_pricing = plan.planpricing_set.filter(pricing=recurring.pricing).first()
+        if plan_pricing is None:
+            accounts_logger.warning(
+                "Plan '%s' [id=%d] has no pricing for period %s; renewal of "
+                "user '%s' [id=%d] keeps its previous amount",
+                plan,
+                plan.pk,
+                recurring.pricing,
+                self.user,
+                self.user.pk,
+            )
+            return
+        recurring.amount = plan_pricing.price
+        recurring.save(update_fields=["amount"])
 
     def extend_account(self, plan, pricing):
         """
@@ -415,6 +462,7 @@ class AbstractUserPlan(BaseMixin, models.Model):
                 self.expire = None
 
             self.save()
+            self._reprice_recurring_for_plan(plan)
             account_change_plan.send(sender=self, user=self.user)
             if getattr(settings, "PLANS_SEND_EMAILS_PLAN_CHANGED", True):
                 mail_context = {"user": self.user, "userplan": self, "plan": plan}

--- a/plans/tests/tests.py
+++ b/plans/tests/tests.py
@@ -2566,6 +2566,83 @@ class BillingInfoViewTestCase(TestCase):
 
 
 class RecurringPlansTestCase(TestCase):
+    def _armed_userplan(self, plan_price=10):
+        plan = baker.make("Plan", name="Basic")
+        pricing = baker.make("Pricing", period=30)
+        baker.make("PlanPricing", plan=plan, pricing=pricing, price=plan_price)
+        up = baker.make("UserPlan", plan=plan)
+        baker.make(
+            "RecurringUserPlan",
+            user_plan=up,
+            pricing=pricing,
+            amount=plan_price,
+            tax=20,
+            currency="USD",
+            token="old-token",
+            token_verified=True,
+            renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+        )
+        return up, pricing
+
+    def test_set_plan_renewal_with_plan_change_order_keeps_subscription_terms(self):
+        """A plan-change order (no pricing) must not overwrite an armed
+        renewal's pricing and amount - only the token-related values change."""
+        up, pricing = self._armed_userplan()
+        change_order = baker.make("Order", pricing=None, amount=7, tax=None, currency="EUR")
+
+        up.set_plan_renewal(
+            order=change_order,
+            renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK,
+            token="new-token",
+            card_masked_number="4321",
+        )
+
+        up.recurring.refresh_from_db()
+        self.assertEqual(up.recurring.pricing, pricing)
+        self.assertEqual(up.recurring.amount, 10)
+        self.assertEqual(up.recurring.tax, 20)
+        self.assertEqual(up.recurring.currency, "USD")
+        self.assertEqual(up.recurring.token, "new-token")
+        self.assertEqual(up.recurring.card_masked_number, "4321")
+
+    def test_set_plan_renewal_fresh_recurring_still_copies_the_order(self):
+        """No armed renewal yet: the order's terms are the only ones known."""
+        up = baker.make("UserPlan")
+        order = baker.make("Order", pricing=None, amount=10)
+
+        up.set_plan_renewal(
+            order=order, renewal_triggered_by=AbstractRecurringUserPlan.RENEWAL_TRIGGERED_BY.TASK
+        )
+
+        self.assertEqual(up.recurring.amount, 10)
+        self.assertIsNone(up.recurring.pricing)
+
+    def test_plan_change_reprices_the_renewal_for_the_new_plan(self):
+        up, pricing = self._armed_userplan(plan_price=10)
+        better = baker.make("Plan", name="Pro")
+        baker.make("PlanPricing", plan=better, pricing=pricing, price=25)
+
+        up.extend_account(better, None)
+
+        up.recurring.refresh_from_db()
+        self.assertEqual(up.plan, better)
+        self.assertEqual(up.recurring.pricing, pricing)
+        self.assertEqual(up.recurring.amount, 25)
+        self.assertEqual(up.recurring.token, "old-token")
+
+    def test_plan_change_without_that_period_keeps_the_renewal_amount(self):
+        """The new plan does not sell the period the account renews on: better
+        to keep renewing on known terms than to invent a price."""
+        up, pricing = self._armed_userplan(plan_price=10)
+        other = baker.make("Plan", name="Yearly only")
+        baker.make("PlanPricing", plan=other, pricing=baker.make("Pricing", period=365), price=99)
+
+        up.extend_account(other, None)
+
+        up.recurring.refresh_from_db()
+        self.assertEqual(up.recurring.amount, 10)
+        self.assertEqual(up.recurring.pricing, pricing)
+
     def test_set_plan_renewal(self):
         """Test that UserPlan.set_plan_renewal() method"""
         up = baker.make("UserPlan")


### PR DESCRIPTION
## The bug

A plan change is bought as an order **without a pricing** (`UserPlan.extend_account(plan, pricing=None)`, which the code itself annotates as "the order is upgrade plan, not buy new pricing"). Around a `RecurringUserPlan` that had two consequences:

1. `extend_account` switched the plan but never touched the renewal → the account **kept renewing at the price of the plan it had left** (upgrade Basic → Pro, renew Pro at the Basic price, indefinitely).
2. `set_plan_renewal(order=<change order>)` copied the order's fields verbatim → an armed renewal ended up with `pricing=None` and the one-off difference as its `amount` — **a subscription that renews nothing**. django-plans-payments' `set_renew_token` hits exactly this when a change order is paid with a recurring variant.

Found while wiring plan upgrades into a production site's billing page; verified against real data before fixing.

## The fix

- `extend_account(plan, None)` re-prices the renewal to `plan`'s `PlanPricing` for the period it already renews on. The `Pricing` row is shared across plans, so only `amount` changes. If the new plan does not sell that period, nothing is changed and a warning is logged; `account_change_plan` still fires right after, so a project can apply its own policy (e.g. carry a discount ratio across).
- `set_plan_renewal` keeps the subscription's own pricing/amount/tax/currency when the order has no pricing **and** a renewal is already armed, taking only the token-related kwargs. A fresh renewal still copies the order as before — the existing `test_set_plan_renewal` (whose baker order has no pricing) is untouched and passes.

## Tests

Four new cases in `RecurringPlansTestCase`: change order keeps subscription terms; fresh renewal still copies the order; plan change re-prices to the new plan; plan without that period leaves the amount alone. Full `plans` suite: 236 tests OK. `ruff check` clean (`ruff format` reports pre-existing line-length differences in these files on `master`; left untouched to keep the diff focused).

Companion PR: https://github.com/PetrDlouhy/django-plans-payments/pull/25 makes `set_renew_token` defensive on older django-plans too.
